### PR TITLE
Adding 256 bit support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
       - name: JavaScript decrypt test
         working-directory: ./js
         run: |
-          npx mocha --require esm --grep "should decrypt a message using RSA scheme" test.mjs
+          npx mocha --grep "should decrypt a message using RSA scheme" test.mjs
 
       - name: Python decrypt test
         working-directory: ./python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
       - name: JavaScript tests
         working-directory: ./js
         run: |
-          npx mocha --require esm --grep "^(?!.*should decrypt a message using RSA scheme$)" test.mjs
+          npx mocha --fgrep "should decrypt a message using RSA scheme" --invert test.mjs
 
       - name: Python tests
         working-directory: ./python

--- a/golang_cli/crypto/crypto_test.go
+++ b/golang_cli/crypto/crypto_test.go
@@ -353,7 +353,7 @@ func readTwoHexStringsFromFile(path string) ([]byte, []byte, error) {
 	hexStrings := bytes.Split(data, []byte("\n"))
 
 	// Convert the hex strings to bytes
-	if len(hexStrings) != 2 {
+	if len(hexStrings) < 2 {
 		return nil, nil, fmt.Errorf("Expected two hex strings in the file")
 	}
 

--- a/js/crypto.js
+++ b/js/crypto.js
@@ -11,6 +11,8 @@ export const funcSigSize = 4;
 export const ctSize = 32;
 export const keySize = 32;
 export const hexBase = 16;
+export const maxPlaintextBitSize = 256;
+
 
 export function encrypt(key, plaintext) {
     
@@ -53,17 +55,17 @@ export function decrypt(key, r, ciphertext, r2=null, ciphertext2=null) {
 
     // Ensure key size is 128 bits (16 bytes)
     if (key.length != block_size) {
-        throw new RangeError("Key size must be 128 bits.");
+        throw new RangeError("Key size must be 128 bits, received " + key.length + " bytes.");
     }
 
     // Ensure random size is 128 bits (16 bytes)
     if (r.length != block_size) {
-        throw new RangeError("Random size must be 128 bits.");
+        throw new RangeError("Random size must be 128 bits, received " + r.length + " bytes.");
     }
 
     if (r2 !== null) {
         if (r2.length !== block_size) {
-            throw new RangeError("Random2 size must be 128 bits.");
+            throw new RangeError("Random2 size must be 128 bits, received " + r2.length + " bytes.");
         }
         if (ciphertext2 === null) {
             throw new RangeError("Ciphertext2 is required.");
@@ -72,7 +74,7 @@ export function decrypt(key, r, ciphertext, r2=null, ciphertext2=null) {
 
     if (ciphertext2 !== null) {
         if (ciphertext2.length !== block_size) {
-            throw new RangeError("Ciphertext2 size must be 128 bits.");
+            throw new RangeError("Ciphertext2 size must be 128 bits, received " + ciphertext2.length + " bytes.");
         }
 
         if (r2 === null) {
@@ -213,31 +215,29 @@ export function signEIP191(message, key) {
 }
 
 function writeBigUInt128BE(buffer, value, offset = 0) {
-    const hexString = value.toString(16).padStart(32, '0');
+    const hexString = value.toString(hexBase).padStart(ctSize, '0');
     const bytes = Buffer.from(hexString, 'hex');
     bytes.copy(buffer, offset);
 }
 
 function writeBigUInt256BE(buffer, value, offset = 0) {
-    const hexString = value.toString(16).padStart(64, '0');
+    const hexString = value.toString(hexBase).padStart(ctSize*2, '0');
     const bytes = Buffer.from(hexString, 'hex');
+    if (buffer.length > bytes.length) {
+        offset = buffer.length - bytes.length;
+    }
     bytes.copy(buffer, offset);
 }
 
 export function prepareCompactIT(plaintext, userAesKey, sender, contract, hashFunc, signingKey, eip191=false) {
-    const { ctInt, signature } = prepareIT(plaintext, userAesKey, sender, contract, hashFunc, signingKey, eip191);
-    if (ctInt.toString(2).length <= 128) { // case of 128 bits plaintext or less
-        return { ctInt, signature };
-    } else {                               // case of 256 bits plaintext or more
-        // Convert BigInt to Buffer 
-        const ctBuffer = Buffer.alloc(64); // Allocate a buffer of size 32 bytes
-        writeBigUInt256BE(ctBuffer, ctInt); // Write the uint256 value to the buffer as big-endian
-        const ct1 = ctBuffer.slice(0, 32);
-        const ct2 = ctBuffer.slice(32);
-        
-        const ctInt1 = BigInt('0x' + ct1.toString('hex'));
-        const ctInt2 = BigInt('0x' + ct2.toString('hex'));
-        return { ctInt1, ctInt2, signature };
+    const { ct, signature } = prepareIT(plaintext, userAesKey, sender, contract, hashFunc, signingKey, eip191);
+    if (ct.length <= ctSize) {
+        return { c, signature };
+    } else { 
+        const ct1 = ct.slice(0, ctSize);
+        const ct2 = ct.slice(ctSize);
+
+        return { ct1, ct2, signature };
     }
 }
 
@@ -253,37 +253,34 @@ export function prepareIT(plaintext, userAesKey, sender, contract, hashFunc, sig
 
     let ct;
 
-    if (bitSize <= 128) {
-        const plaintextBytes = Buffer.alloc(16); // Allocate a buffer of size 16 bytes
+    if (bitSize <= maxPlaintextBitSize/2) {
+        const plaintextBytes = Buffer.alloc(block_size); // Allocate a buffer of size 16 bytes
         writeBigUInt128BE(plaintextBytes, plaintextBigInt); // Write the uint128 value to the buffer as big-endian
         // Encrypt the plaintext using AES key
         const {ciphertext, r} = encrypt(userAesKey, plaintextBytes);
 
         ct = Buffer.concat([ciphertext, r]);
-    } else if (bitSize <= 256) {
-        const plaintextBytes = Buffer.alloc(32); // Allocate a buffer of size 32 bytes
+    } else if (bitSize <= maxPlaintextBitSize) {
+        const plaintextBytes = Buffer.alloc(ctSize); // Allocate a buffer of size 32 bytes
         writeBigUInt256BE(plaintextBytes, plaintextBigInt); // Write the uint256 value to the buffer as big-endian
         
         // Encrypt each part of the plaintext using AES key
-        const result1 = encrypt(userAesKey, plaintextBytes.slice(0, 16));
-        const result2 = encrypt(userAesKey, plaintextBytes.slice(16));
+        const result1 = encrypt(userAesKey, plaintextBytes.slice(0, block_size));
+        const result2 = encrypt(userAesKey, plaintextBytes.slice(block_size));
         
         // Now destructure
         const { ciphertext: ciphertext1, r: r1 } = result1;
         const { ciphertext: ciphertext2, r: r2 } = result2;
 
         ct = Buffer.concat([ciphertext1, r1, ciphertext2, r2]);
-    } else if (bitSize > 256 ) {
+    } else if (bitSize > maxPlaintextBitSize) {
         throw new RangeError("Plaintext size must be 256 bits or smaller.");
     }
 
     // Sign the message
     const signature = signIT(senderBytes, contractBytes, hashFunc, ct, signingKey, eip191);
 
-    // Convert the ciphertext to BigInt
-    const ctInt = BigInt('0x' + ct.toString('hex'));
-
-    return { ctInt, signature };
+    return { ct, signature };
 }
 
 export function generateRSAKeyPair() {

--- a/js/crypto.js
+++ b/js/crypto.js
@@ -235,7 +235,9 @@ export function prepareCompactIT(plaintext, userAesKey, sender, contract, hashFu
         throw new RangeError("Plaintext size must be 128 bits or smaller. To prepare a 256 bit plaintext, use prepareCompactIT256 instead.");
     }
     const { ct, signature } = prepareIT(plaintext, userAesKey, sender, contract, hashFunc, signingKey, eip191, false);
-    return { ct, signature };
+    // Convert Buffer to uint256 (BigInt) for Solidity compatibility
+    const ciphertextUint = BigInt('0x' + ct.toString('hex'));
+    return { ciphertext: ciphertextUint, signature };
 }
 
 export function prepareCompactIT256(plaintext, userAesKey, sender, contract, hashFunc, signingKey, eip191=false) {
@@ -245,10 +247,14 @@ export function prepareCompactIT256(plaintext, userAesKey, sender, contract, has
     }
 
     const { ct, signature } = prepareIT(plaintext, userAesKey, sender, contract, hashFunc, signingKey, eip191, true);
-    const ctHigh = ct.slice(0, ctSize);
-    const ctLow = ct.slice(ctSize);
+    const ciphertextHigh = ct.slice(0, ctSize);
+    const ciphertextLow = ct.slice(ctSize);
 
-    return { ct: {ctHigh, ctLow}, signature };
+    // Convert Buffer to uint256 (BigInt) for Solidity compatibility
+    const ciphertextHighUint = BigInt('0x' + ciphertextHigh.toString('hex'));
+    const ciphertextLowUint = BigInt('0x' + ciphertextLow.toString('hex'));
+
+    return { ciphertext: {ciphertextHigh: ciphertextHighUint, ciphertextLow: ciphertextLowUint}, signature };
     
 }
 
@@ -273,7 +279,7 @@ export function prepareIT(plaintext, userAesKey, sender, contract, hashFunc, sig
             const zero = BigInt(0);
             const zeroBytes = Buffer.alloc(block_size);
             writeBigUInt128BE(zeroBytes, zero);
-            const {ciphertextHigh, rHigh} = encrypt(userAesKey, zeroBytes);
+            const {ciphertext: ciphertextHigh, r: rHigh} = encrypt(userAesKey, zeroBytes);
             ct = Buffer.concat([ciphertextHigh, rHigh, ciphertext, r]);
         } else {
             ct = Buffer.concat([ciphertext, r]);

--- a/js/crypto.js
+++ b/js/crypto.js
@@ -45,7 +45,7 @@ export function encrypt(key, plaintext) {
     return { ciphertext, r };
 }
 
-export function decrypt(key, r, ciphertext) {
+export function decrypt(key, r, ciphertext, r2=null, ciphertext2=null) {
 
     if (ciphertext.length !== block_size) {
         throw new RangeError("Ciphertext size must be 128 bits.");
@@ -61,6 +61,25 @@ export function decrypt(key, r, ciphertext) {
         throw new RangeError("Random size must be 128 bits.");
     }
 
+    if (r2 !== null) {
+        if (r2.length !== block_size) {
+            throw new RangeError("Random2 size must be 128 bits.");
+        }
+        if (ciphertext2 === null) {
+            throw new RangeError("Ciphertext2 is required.");
+        }
+    }
+
+    if (ciphertext2 !== null) {
+        if (ciphertext2.length !== block_size) {
+            throw new RangeError("Ciphertext2 size must be 128 bits.");
+        }
+
+        if (r2 === null) {
+            throw new RangeError("Random2 is required.");
+        }
+    }
+
     // Create a new AES decipher using the provided key
     const cipher = crypto.createCipheriv('aes-128-ecb', key, null);
 
@@ -71,6 +90,19 @@ export function decrypt(key, r, ciphertext) {
     const plaintext = Buffer.alloc(encryptedR.length);
     for (let i = 0; i < encryptedR.length; i++) {
         plaintext[i] = encryptedR[i] ^ ciphertext[i];
+    }
+
+    if (r2 !== null && ciphertext2 !== null) {
+        // Encrypt the random value 'r' using AES in ECB mode
+        const encryptedR2 = cipher.update(r2);
+
+        // XOR the encrypted random value 'r' with the ciphertext to obtain the plaintext
+        const plaintext2 = Buffer.alloc(encryptedR2.length);
+        for (let i = 0; i < encryptedR2.length; i++) {
+            plaintext2[i] = encryptedR2[i] ^ ciphertext2[i];
+        }
+
+        plaintext = Buffer.concat([plaintext, plaintext2]);
     }
 
     return plaintext;
@@ -134,8 +166,8 @@ export function signIT(sender, addr, funcSig, ct, key, eip191=false) {
     if (funcSig.length !== funcSigSize) {
         throw new RangeError(`Invalid signature size: ${funcSig.length} bytes, must be ${funcSigSize} bytes`);
     }
-    if (ct.length !== ctSize) {
-        throw new RangeError(`Invalid ct length: ${ct.length} bytes, must be ${ctSize} bytes`);
+    if (ct.length !== ctSize && ct.length !== 2*ctSize) {
+        throw new RangeError(`Invalid ct length: ${ct.length} bytes, must be ${ctSize} bytes in case of 128 bits plaintext or less, or ${2*ctSize} bytes in case of 256 bits plaintext or less`);
     }
     // Ensure the key is the correct length
     if (key.length !== keySize) {
@@ -180,6 +212,18 @@ export function signEIP191(message, key) {
     return Buffer.concat([Buffer.from(signature.r), Buffer.from(signature.s), Buffer.from([signature.v])]);
 }
 
+function writeBigUInt128BE(buffer, value, offset = 0) {
+    const hexString = value.toString(16).padStart(32, '0');
+    const bytes = Buffer.from(hexString, 'hex');
+    bytes.copy(buffer, offset);
+}
+
+function writeBigUInt256BE(buffer, value, offset = 0) {
+    const hexString = value.toString(16).padStart(64, '0');
+    const bytes = Buffer.from(hexString, 'hex');
+    bytes.copy(buffer, offset);
+}
+
 export function prepareIT(plaintext, userAesKey, sender, contract, hashFunc, signingKey, eip191=false) {
 
     // Get the bytes of the sender, contract, and function signature
@@ -187,12 +231,32 @@ export function prepareIT(plaintext, userAesKey, sender, contract, hashFunc, sig
     const contractBytes = toBuffer(contract)
     
     // Convert the plaintext to bytes
-    const plaintextBytes = Buffer.alloc(8); // Allocate a buffer of size 8 bytes
-    plaintextBytes.writeBigUInt64BE(BigInt(plaintext)); // Write the uint64 value to the buffer as little-endian
+    const plaintextBigInt = BigInt(plaintext);
+    const bitSize = plaintextBigInt.toString(2).length;
 
-    // Encrypt the plaintext using AES key
-    const { ciphertext, r } = encrypt(userAesKey, plaintextBytes);
-    let ct = Buffer.concat([ciphertext, r]);
+    console.log("plaintext bit size: ", bitSize);
+
+    let ct;
+
+    if (bitSize <= 128) {
+        const plaintextBytes = Buffer.alloc(16); // Allocate a buffer of size 16 bytes
+        writeBigUInt128BE(plaintextBytes, plaintextBigInt); // Write the uint128 value to the buffer as big-endian
+        // Encrypt the plaintext using AES key
+        const {ciphertext, r} = encrypt(userAesKey, plaintextBytes);
+
+        ct = Buffer.concat([ciphertext, r]);
+    } else if (bitSize <= 256) {
+        const plaintextBytes = Buffer.alloc(32); // Allocate a buffer of size 32 bytes
+        writeBigUInt256BE(plaintextBytes, plaintextBigInt); // Write the uint256 value to the buffer as big-endian
+
+        // Encrypt each part of the plaintext using AES key
+        const { ciphertext1, r1 } = encrypt(userAesKey, plaintextBytes.slice(0, 16));
+        const { ciphertext2, r2 } = encrypt(userAesKey, plaintextBytes.slice(16));
+
+        ct = Buffer.concat([ciphertext1, r1, ciphertext2, r2]);
+    } else if (bitSize > 256 ) {
+        throw new RangeError("Plaintext size must be 256 bits or smaller.");
+    }
 
     // Sign the message
     const signature = signIT(senderBytes, contractBytes, hashFunc, ct, signingKey, eip191);

--- a/js/crypto.js
+++ b/js/crypto.js
@@ -220,7 +220,7 @@ function writeBigUInt128BE(buffer, value, offset = 0) {
     bytes.copy(buffer, offset);
 }
 
-function writeBigUInt256BE(buffer, value, offset = 0) {
+export function writeBigUInt256BE(buffer, value, offset = 0) {
     const hexString = value.toString(hexBase).padStart(ctSize*2, '0');
     const bytes = Buffer.from(hexString, 'hex');
     if (buffer.length > bytes.length) {

--- a/js/crypto.js
+++ b/js/crypto.js
@@ -230,18 +230,29 @@ function writeBigUInt256BE(buffer, value, offset = 0) {
 }
 
 export function prepareCompactIT(plaintext, userAesKey, sender, contract, hashFunc, signingKey, eip191=false) {
-    const { ct, signature } = prepareIT(plaintext, userAesKey, sender, contract, hashFunc, signingKey, eip191);
-    if (ct.length <= ctSize) {
-        return { c, signature };
-    } else { 
-        const ct1 = ct.slice(0, ctSize);
-        const ct2 = ct.slice(ctSize);
-
-        return { ct1, ct2, signature };
+    const bitSize = plaintext.toString(2).length;
+    if (bitSize > maxPlaintextBitSize/2) {
+        throw new RangeError("Plaintext size must be 128 bits or smaller. To prepare a 256 bit plaintext, use prepareCompactIT256 instead.");
     }
+    const { ct, signature } = prepareIT(plaintext, userAesKey, sender, contract, hashFunc, signingKey, eip191, false);
+    return { ct, signature };
 }
 
-export function prepareIT(plaintext, userAesKey, sender, contract, hashFunc, signingKey, eip191=false) {
+export function prepareCompactIT256(plaintext, userAesKey, sender, contract, hashFunc, signingKey, eip191=false) {
+    const bitSize = plaintext.toString(2).length;
+    if (bitSize > maxPlaintextBitSize) {
+        throw new RangeError("Plaintext size must be between 128 and 256 bits.");
+    }
+
+    const { ct, signature } = prepareIT(plaintext, userAesKey, sender, contract, hashFunc, signingKey, eip191, true);
+    const ctHigh = ct.slice(0, ctSize);
+    const ctLow = ct.slice(ctSize);
+
+    return { ct: {ctHigh, ctLow}, signature };
+    
+}
+
+export function prepareIT(plaintext, userAesKey, sender, contract, hashFunc, signingKey, eip191=false, is256bit=false) {
 
     // Get the bytes of the sender, contract, and function signature
     const senderBytes = toBuffer(sender)
@@ -258,21 +269,28 @@ export function prepareIT(plaintext, userAesKey, sender, contract, hashFunc, sig
         writeBigUInt128BE(plaintextBytes, plaintextBigInt); // Write the uint128 value to the buffer as big-endian
         // Encrypt the plaintext using AES key
         const {ciphertext, r} = encrypt(userAesKey, plaintextBytes);
-
-        ct = Buffer.concat([ciphertext, r]);
+        if (is256bit) {
+            const zero = BigInt(0);
+            const zeroBytes = Buffer.alloc(block_size);
+            writeBigUInt128BE(zeroBytes, zero);
+            const {ciphertextHigh, rHigh} = encrypt(userAesKey, zeroBytes);
+            ct = Buffer.concat([ciphertextHigh, rHigh, ciphertext, r]);
+        } else {
+            ct = Buffer.concat([ciphertext, r]);
+        }
     } else if (bitSize <= maxPlaintextBitSize) {
         const plaintextBytes = Buffer.alloc(ctSize); // Allocate a buffer of size 32 bytes
         writeBigUInt256BE(plaintextBytes, plaintextBigInt); // Write the uint256 value to the buffer as big-endian
         
         // Encrypt each part of the plaintext using AES key
-        const result1 = encrypt(userAesKey, plaintextBytes.slice(0, block_size));
-        const result2 = encrypt(userAesKey, plaintextBytes.slice(block_size));
+        const resultHigh = encrypt(userAesKey, plaintextBytes.slice(0, block_size));
+        const resultLow = encrypt(userAesKey, plaintextBytes.slice(block_size));
         
         // Now destructure
-        const { ciphertext: ciphertext1, r: r1 } = result1;
-        const { ciphertext: ciphertext2, r: r2 } = result2;
+        const { ciphertext: ciphertextHigh, r: rHigh } = resultHigh;
+        const { ciphertext: ciphertextLow, r: rLow } = resultLow;
 
-        ct = Buffer.concat([ciphertext1, r1, ciphertext2, r2]);
+        ct = Buffer.concat([ciphertextHigh, rHigh, ciphertextLow, rLow]);
     } else if (bitSize > maxPlaintextBitSize) {
         throw new RangeError("Plaintext size must be 256 bits or smaller.");
     }

--- a/js/crypto.js
+++ b/js/crypto.js
@@ -87,7 +87,7 @@ export function decrypt(key, r, ciphertext, r2=null, ciphertext2=null) {
     const encryptedR = cipher.update(r);
 
     // XOR the encrypted random value 'r' with the ciphertext to obtain the plaintext
-    const plaintext = Buffer.alloc(encryptedR.length);
+    let plaintext = Buffer.alloc(encryptedR.length);
     for (let i = 0; i < encryptedR.length; i++) {
         plaintext[i] = encryptedR[i] ^ ciphertext[i];
     }
@@ -224,6 +224,23 @@ function writeBigUInt256BE(buffer, value, offset = 0) {
     bytes.copy(buffer, offset);
 }
 
+export function prepareCompactIT(plaintext, userAesKey, sender, contract, hashFunc, signingKey, eip191=false) {
+    const { ctInt, signature } = prepareIT(plaintext, userAesKey, sender, contract, hashFunc, signingKey, eip191);
+    if (ctInt.toString(2).length <= 128) { // case of 128 bits plaintext or less
+        return { ctInt, signature };
+    } else {                               // case of 256 bits plaintext or more
+        // Convert BigInt to Buffer 
+        const ctBuffer = Buffer.alloc(64); // Allocate a buffer of size 32 bytes
+        writeBigUInt256BE(ctBuffer, ctInt); // Write the uint256 value to the buffer as big-endian
+        const ct1 = ctBuffer.slice(0, 32);
+        const ct2 = ctBuffer.slice(32);
+        
+        const ctInt1 = BigInt('0x' + ct1.toString('hex'));
+        const ctInt2 = BigInt('0x' + ct2.toString('hex'));
+        return { ctInt1, ctInt2, signature };
+    }
+}
+
 export function prepareIT(plaintext, userAesKey, sender, contract, hashFunc, signingKey, eip191=false) {
 
     // Get the bytes of the sender, contract, and function signature
@@ -233,8 +250,6 @@ export function prepareIT(plaintext, userAesKey, sender, contract, hashFunc, sig
     // Convert the plaintext to bytes
     const plaintextBigInt = BigInt(plaintext);
     const bitSize = plaintextBigInt.toString(2).length;
-
-    console.log("plaintext bit size: ", bitSize);
 
     let ct;
 
@@ -248,10 +263,14 @@ export function prepareIT(plaintext, userAesKey, sender, contract, hashFunc, sig
     } else if (bitSize <= 256) {
         const plaintextBytes = Buffer.alloc(32); // Allocate a buffer of size 32 bytes
         writeBigUInt256BE(plaintextBytes, plaintextBigInt); // Write the uint256 value to the buffer as big-endian
-
+        
         // Encrypt each part of the plaintext using AES key
-        const { ciphertext1, r1 } = encrypt(userAesKey, plaintextBytes.slice(0, 16));
-        const { ciphertext2, r2 } = encrypt(userAesKey, plaintextBytes.slice(16));
+        const result1 = encrypt(userAesKey, plaintextBytes.slice(0, 16));
+        const result2 = encrypt(userAesKey, plaintextBytes.slice(16));
+        
+        // Now destructure
+        const { ciphertext: ciphertext1, r: r1 } = result1;
+        const { ciphertext: ciphertext2, r: r2 } = result2;
 
         ct = Buffer.concat([ciphertext1, r1, ciphertext2, r2]);
     } else if (bitSize > 256 ) {

--- a/js/crypto.js
+++ b/js/crypto.js
@@ -229,36 +229,7 @@ export function writeBigUInt256BE(buffer, value, offset = 0) {
     bytes.copy(buffer, offset);
 }
 
-export function prepareCompactIT(plaintext, userAesKey, sender, contract, hashFunc, signingKey, eip191=false) {
-    const bitSize = plaintext.toString(2).length;
-    if (bitSize > maxPlaintextBitSize/2) {
-        throw new RangeError("Plaintext size must be 128 bits or smaller. To prepare a 256 bit plaintext, use prepareCompactIT256 instead.");
-    }
-    const { ct, signature } = prepareIT(plaintext, userAesKey, sender, contract, hashFunc, signingKey, eip191, false);
-    // Convert Buffer to uint256 (BigInt) for Solidity compatibility
-    const ciphertextUint = BigInt('0x' + ct.toString('hex'));
-    return { ciphertext: ciphertextUint, signature };
-}
-
-export function prepareCompactIT256(plaintext, userAesKey, sender, contract, hashFunc, signingKey, eip191=false) {
-    const bitSize = plaintext.toString(2).length;
-    if (bitSize > maxPlaintextBitSize) {
-        throw new RangeError("Plaintext size must be between 128 and 256 bits.");
-    }
-
-    const { ct, signature } = prepareIT(plaintext, userAesKey, sender, contract, hashFunc, signingKey, eip191, true);
-    const ciphertextHigh = ct.slice(0, ctSize);
-    const ciphertextLow = ct.slice(ctSize);
-
-    // Convert Buffer to uint256 (BigInt) for Solidity compatibility
-    const ciphertextHighUint = BigInt('0x' + ciphertextHigh.toString('hex'));
-    const ciphertextLowUint = BigInt('0x' + ciphertextLow.toString('hex'));
-
-    return { ciphertext: {ciphertextHigh: ciphertextHighUint, ciphertextLow: ciphertextLowUint}, signature };
-    
-}
-
-export function prepareIT(plaintext, userAesKey, sender, contract, hashFunc, signingKey, eip191=false, is256bit=false) {
+export function prepareIT(plaintext, userAesKey, sender, contract, hashFunc, signingKey, eip191=false) {
 
     // Get the bytes of the sender, contract, and function signature
     const senderBytes = toBuffer(sender)
@@ -267,23 +238,54 @@ export function prepareIT(plaintext, userAesKey, sender, contract, hashFunc, sig
     // Convert the plaintext to bytes
     const plaintextBigInt = BigInt(plaintext);
     const bitSize = plaintextBigInt.toString(2).length;
+    if (bitSize > maxPlaintextBitSize/2) {
+        throw new RangeError("Plaintext size must be 128 bits or smaller. To prepare a 256 bit plaintext, use prepareIT256 instead.");
+    }
+
+    const plaintextBytes = Buffer.alloc(block_size); // Allocate a buffer of size 16 bytes
+    writeBigUInt128BE(plaintextBytes, plaintextBigInt); // Write the uint128 value to the buffer as big-endian
+    // Encrypt the plaintext using AES key
+    const {ciphertext, r} = encrypt(userAesKey, plaintextBytes);
+    let ct = Buffer.concat([ciphertext, r]);
+    
+    // Sign the message
+    const signature = signIT(senderBytes, contractBytes, hashFunc, ct, signingKey, eip191);
+
+    // Convert the ciphertext to BigInt
+    const ctInt = BigInt('0x' + ct.toString('hex'));
+
+    return { ctInt, signature };
+}
+
+export function prepareIT256(plaintext, userAesKey, sender, contract, hashFunc, signingKey, eip191=false, is256bit=false) {
+
+    // Get the bytes of the sender, contract, and function signature
+    const senderBytes = toBuffer(sender)
+    const contractBytes = toBuffer(contract)
+    
+    // Convert the plaintext to bytes
+    const plaintextBigInt = BigInt(plaintext);
+    const bitSize = plaintextBigInt.toString(2).length;
+    if (bitSize > maxPlaintextBitSize) {
+        throw new RangeError("Plaintext size must be between 128 and 256 bits.");
+    }
 
     let ct;
 
+    // In case of 128 bits plaintext, encrypt it as the low part of the ct, and then encrypt the high part of the ct with zeros
     if (bitSize <= maxPlaintextBitSize/2) {
         const plaintextBytes = Buffer.alloc(block_size); // Allocate a buffer of size 16 bytes
         writeBigUInt128BE(plaintextBytes, plaintextBigInt); // Write the uint128 value to the buffer as big-endian
         // Encrypt the plaintext using AES key
         const {ciphertext, r} = encrypt(userAesKey, plaintextBytes);
-        if (is256bit) {
-            const zero = BigInt(0);
-            const zeroBytes = Buffer.alloc(block_size);
-            writeBigUInt128BE(zeroBytes, zero);
-            const {ciphertext: ciphertextHigh, r: rHigh} = encrypt(userAesKey, zeroBytes);
-            ct = Buffer.concat([ciphertextHigh, rHigh, ciphertext, r]);
-        } else {
-            ct = Buffer.concat([ciphertext, r]);
-        }
+
+        // Encrypt the high part of the ct with zeros
+        const zero = BigInt(0);
+        const zeroBytes = Buffer.alloc(block_size);
+        writeBigUInt128BE(zeroBytes, zero);
+        const {ciphertext: ciphertextHigh, r: rHigh} = encrypt(userAesKey, zeroBytes);
+        ct = Buffer.concat([ciphertextHigh, rHigh, ciphertext, r]);
+        
     } else if (bitSize <= maxPlaintextBitSize) {
         const plaintextBytes = Buffer.alloc(ctSize); // Allocate a buffer of size 32 bytes
         writeBigUInt256BE(plaintextBytes, plaintextBigInt); // Write the uint256 value to the buffer as big-endian
@@ -304,7 +306,14 @@ export function prepareIT(plaintext, userAesKey, sender, contract, hashFunc, sig
     // Sign the message
     const signature = signIT(senderBytes, contractBytes, hashFunc, ct, signingKey, eip191);
 
-    return { ct, signature };
+    const ciphertextHigh = ct.slice(0, ctSize);
+    const ciphertextLow = ct.slice(ctSize);
+
+    // Convert Buffer to uint256 (BigInt) for Solidity compatibility
+    const ciphertextHighUint = BigInt('0x' + ciphertextHigh.toString('hex'));
+    const ciphertextLowUint = BigInt('0x' + ciphertextLow.toString('hex'));
+
+    return { ciphertext: {ciphertextHigh: ciphertextHighUint, ciphertextLow: ciphertextLowUint}, signature };
 }
 
 export function generateRSAKeyPair() {

--- a/js/test.mjs
+++ b/js/test.mjs
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
-import { encrypt, decrypt, loadAesKey, writeAesKey, generateAesKey, signIT, generateRSAKeyPair, encryptRSA, decryptRSA, getFuncSig, prepareIT, generateECDSAPrivateKey, prepareCompactIT256 } from './crypto.js';
-import { block_size, addressSize, funcSigSize, hexBase } from './crypto.js';
+import { encrypt, decrypt, loadAesKey, writeAesKey, generateAesKey, signIT, generateRSAKeyPair, encryptRSA, decryptRSA, getFuncSig, prepareIT, generateECDSAPrivateKey, prepareCompactIT256, writeBigUInt256BE } from './crypto.js';
+import { block_size, ctSize, addressSize, funcSigSize, hexBase } from './crypto.js';
 import fs from 'fs';
 import crypto from 'crypto';
 import ethereumjsUtil, {hashPersonalMessage} from 'ethereumjs-util';
@@ -283,13 +283,14 @@ describe('Crypto Tests', () => {
         // Act
         // Generate the signature
         const hash_func = getFuncSig(funcSig);
-        const {ct, signature} = prepareCompactIT256(plaintext, userKey, sender, contract, hash_func, signingKey);
-        
-        const ctHex1 = ct.ctHigh.toString('hex').padStart(64, '0');
-        const ctHex2 = ct.ctLow.toString('hex').padStart(64, '0');
-        
+        const {ciphertext, signature} = prepareCompactIT256(plaintext, userKey, sender, contract, hash_func, signingKey);
+
+        const ctHighBytes = Buffer.alloc(ctSize); // Allocate a buffer of size 32 bytes
+        writeBigUInt256BE(ctHighBytes, ciphertext.ciphertextHigh); // Write the uint256 value to the buffer as big-endian
+        const ctLowBytes = Buffer.alloc(ctSize); // Allocate a buffer of size 32 bytes
+        writeBigUInt256BE(ctLowBytes, ciphertext.ciphertextLow); // Write the uint256 value to the buffer as big-endian
         // Decrypt the ct and check the decrypted value is equal to the plaintext
-        const decryptedBuffer = decrypt(userKey, ct.ctHigh.subarray(block_size, ct.ctHigh.length), ct.ctHigh.subarray(0, block_size), ct.ctLow.subarray(block_size, ct.ctLow.length), ct.ctLow.subarray(0, block_size));
+        const decryptedBuffer = decrypt(userKey, ctHighBytes.subarray(block_size, ctHighBytes.length), ctHighBytes.subarray(0, block_size), ctLowBytes.subarray(block_size, ctLowBytes.length), ctLowBytes.subarray(0, block_size));
 
         // Convert the plaintext to bytes
         const hexString = plaintext.toString(16).padStart(64, '0');

--- a/js/test.mjs
+++ b/js/test.mjs
@@ -1,5 +1,5 @@
 import { assert } from 'chai';
-import { encrypt, decrypt, loadAesKey, writeAesKey, generateAesKey, signIT, generateRSAKeyPair, encryptRSA, decryptRSA, getFuncSig, prepareIT, generateECDSAPrivateKey, prepareCompactIT256, writeBigUInt256BE } from './crypto.js';
+import { encrypt, decrypt, loadAesKey, writeAesKey, generateAesKey, signIT, generateRSAKeyPair, encryptRSA, decryptRSA, getFuncSig, prepareIT, generateECDSAPrivateKey, prepareIT256, writeBigUInt256BE } from './crypto.js';
 import { block_size, ctSize, addressSize, funcSigSize, hexBase } from './crypto.js';
 import fs from 'fs';
 import crypto from 'crypto';
@@ -252,15 +252,17 @@ describe('Crypto Tests', () => {
         // Act
         // Generate the signature
         const hash_func = getFuncSig(funcSig);
-        const {ct, signature} = prepareIT(plaintext, userKey, sender, contract, hash_func, signingKey);
+        const {ctInt, signature} = prepareIT(plaintext, userKey, sender, contract, hash_func, signingKey);
 
-        const ctHex = ct.toString('hex');
+        const ctHex = ctInt.toString(hexBase);
+        // Create a Buffer to hold the bytes
+        const ctBuffer = Buffer.from(ctHex, 'hex'); 
         
         // Write Buffer to file to later check in Go
         fs.writeFileSync("test_jsIT.txt", ctHex + "\n" + signature.toString('hex'));
 
         // Decrypt the ct and check the decrypted value is equal to the plaintext
-        const decryptedBuffer = decrypt(userKey, ct.subarray(block_size, ct.length), ct.subarray(0, block_size));
+        const decryptedBuffer = decrypt(userKey, ctBuffer.subarray(block_size, ctBuffer.length), ctBuffer.subarray(0, block_size));
 
         // Convert the plaintext to bytes
         const hexString = plaintext.toString(16);
@@ -283,7 +285,7 @@ describe('Crypto Tests', () => {
         // Act
         // Generate the signature
         const hash_func = getFuncSig(funcSig);
-        const {ciphertext, signature} = prepareCompactIT256(plaintext, userKey, sender, contract, hash_func, signingKey);
+        const {ciphertext, signature} = prepareIT256(plaintext, userKey, sender, contract, hash_func, signingKey);
 
         const ctHighBytes = Buffer.alloc(ctSize); // Allocate a buffer of size 32 bytes
         writeBigUInt256BE(ctHighBytes, ciphertext.ciphertextHigh); // Write the uint256 value to the buffer as big-endian

--- a/js/test.mjs
+++ b/js/test.mjs
@@ -252,17 +252,15 @@ describe('Crypto Tests', () => {
         // Act
         // Generate the signature
         const hash_func = getFuncSig(funcSig);
-        const {ctInt, signature} = prepareIT(plaintext, userKey, sender, contract, hash_func, signingKey);
+        const {ct, signature} = prepareIT(plaintext, userKey, sender, contract, hash_func, signingKey);
 
-        const ctHex = ctInt.toString(hexBase);
-        // Create a Buffer to hold the bytes
-        const ctBuffer = Buffer.from(ctHex, 'hex'); 
-
+        const ctHex = ct.toString('hex');
+        
         // Write Buffer to file to later check in Go
         fs.writeFileSync("test_jsIT.txt", ctHex + "\n" + signature.toString('hex'));
 
         // Decrypt the ct and check the decrypted value is equal to the plaintext
-        const decryptedBuffer = decrypt(userKey, ctBuffer.subarray(block_size, ctBuffer.length), ctBuffer.subarray(0, block_size));
+        const decryptedBuffer = decrypt(userKey, ct.subarray(block_size, ct.length), ct.subarray(0, block_size));
 
         // Convert the plaintext to bytes
         const hexString = plaintext.toString(16);
@@ -275,7 +273,7 @@ describe('Crypto Tests', () => {
     it('should prepare IT 256 bits using fixed data', () => {
         // Arrange
         // Simulate the generation of random bytes
-        const plaintext = BigInt("1809251394333065553493296640760748560207343510400633813116524750123642650623");
+        const plaintext = BigInt("34028236692093846346337460743176821145600");
         const userKey = Buffer.from('b3c3fe73c1bb91862b166a29fe1d63e9', 'hex');;
         const sender = new ethereumjsUtil.Address(ethereumjsUtil.toBuffer(Buffer.from('d67fe7792f18fbd663e29818334a050240887c28', 'hex')));
         const contract = new ethereumjsUtil.Address(ethereumjsUtil.toBuffer(Buffer.from('69413851f025306dbe12c48ff2225016fc5bbe1b', 'hex')));
@@ -285,16 +283,13 @@ describe('Crypto Tests', () => {
         // Act
         // Generate the signature
         const hash_func = getFuncSig(funcSig);
-        const {ctInt1, ctInt2, signature} = prepareCompactIT(plaintext, userKey, sender, contract, hash_func, signingKey);
+        const {ct1, ct2, signature} = prepareCompactIT(plaintext, userKey, sender, contract, hash_func, signingKey);
 
-        const ctHex1 = ctInt1.toString(hexBase);
-        const ctHex2 = ctInt2.toString(hexBase);
-        // Create a Buffer to hold the bytes
-        const ctBuffer1 = Buffer.from(ctHex1, 'hex'); 
-        const ctBuffer2 = Buffer.from(ctHex2, 'hex'); 
-
+        const ctHex1 = ct1.toString('hex').padStart(64, '0');
+        const ctHex2 = ct2.toString('hex').padStart(64, '0');
+        
         // Decrypt the ct and check the decrypted value is equal to the plaintext
-        const decryptedBuffer = decrypt(userKey, ctBuffer1.subarray(block_size, ctBuffer1.length), ctBuffer1.subarray(0, block_size), ctBuffer2.subarray(block_size, ctBuffer2.length), ctBuffer2.subarray(0, block_size));
+        const decryptedBuffer = decrypt(userKey, ct1.subarray(block_size, ct1.length), ct1.subarray(0, block_size), ct2.subarray(block_size, ct2.length), ct2.subarray(0, block_size));
 
         // Convert the plaintext to bytes
         const hexString = plaintext.toString(16).padStart(64, '0');

--- a/js/test.mjs
+++ b/js/test.mjs
@@ -281,7 +281,7 @@ describe('Crypto Tests', () => {
         // Act
         const ciphertext = encryptRSA(publicKey, plaintext);
         
-        const hexString = privateKey.toString('hex') + "\n" + publicKey.toString('hex');
+        const hexString = privateKey.toString('hex') + "\n" + publicKey.toString('hex') + "\n" + ciphertext.toString('hex');
 
         // Write buffer to the file
         const filename = 'test_jsRSAEncryption.txt'; // Name of the file to write to

--- a/js/test.mjs
+++ b/js/test.mjs
@@ -1,5 +1,5 @@
 import { assert } from 'chai';
-import { encrypt, decrypt, loadAesKey, writeAesKey, generateAesKey, signIT, generateRSAKeyPair, encryptRSA, decryptRSA, getFuncSig, prepareIT, generateECDSAPrivateKey } from './crypto.js';
+import { encrypt, decrypt, loadAesKey, writeAesKey, generateAesKey, signIT, generateRSAKeyPair, encryptRSA, decryptRSA, getFuncSig, prepareIT, generateECDSAPrivateKey, prepareCompactIT } from './crypto.js';
 import { block_size, addressSize, funcSigSize, hexBase } from './crypto.js';
 import fs from 'fs';
 import crypto from 'crypto';
@@ -269,6 +269,39 @@ describe('Crypto Tests', () => {
         const plaintextBytes = Buffer.from(hexString, 'hex'); 
         // Assert
         assert.deepStrictEqual(plaintextBytes, decryptedBuffer.subarray(decryptedBuffer.length - plaintextBytes.length, decryptedBuffer.length));
+    });
+
+    // Test case for verify signature
+    it('should prepare IT 256 bits using fixed data', () => {
+        // Arrange
+        // Simulate the generation of random bytes
+        const plaintext = BigInt("1809251394333065553493296640760748560207343510400633813116524750123642650623");
+        const userKey = Buffer.from('b3c3fe73c1bb91862b166a29fe1d63e9', 'hex');;
+        const sender = new ethereumjsUtil.Address(ethereumjsUtil.toBuffer(Buffer.from('d67fe7792f18fbd663e29818334a050240887c28', 'hex')));
+        const contract = new ethereumjsUtil.Address(ethereumjsUtil.toBuffer(Buffer.from('69413851f025306dbe12c48ff2225016fc5bbe1b', 'hex')));
+        const funcSig = 'test(bytes)';
+        const signingKey = Buffer.from('3840f44be5805af188e9b42dda56eb99eefc88d7a6db751017ff16d0c5f8143e', 'hex');
+
+        // Act
+        // Generate the signature
+        const hash_func = getFuncSig(funcSig);
+        const {ctInt1, ctInt2, signature} = prepareCompactIT(plaintext, userKey, sender, contract, hash_func, signingKey);
+
+        const ctHex1 = ctInt1.toString(hexBase);
+        const ctHex2 = ctInt2.toString(hexBase);
+        // Create a Buffer to hold the bytes
+        const ctBuffer1 = Buffer.from(ctHex1, 'hex'); 
+        const ctBuffer2 = Buffer.from(ctHex2, 'hex'); 
+
+        // Decrypt the ct and check the decrypted value is equal to the plaintext
+        const decryptedBuffer = decrypt(userKey, ctBuffer1.subarray(block_size, ctBuffer1.length), ctBuffer1.subarray(0, block_size), ctBuffer2.subarray(block_size, ctBuffer2.length), ctBuffer2.subarray(0, block_size));
+
+        // Convert the plaintext to bytes
+        const hexString = plaintext.toString(16).padStart(64, '0');
+        const plaintextBytes = Buffer.from(hexString, 'hex'); 
+
+        // Assert
+        assert.deepStrictEqual(plaintextBytes, decryptedBuffer);
     });
 
     // Test case for test rsa encryption scheme

--- a/js/test.mjs
+++ b/js/test.mjs
@@ -1,5 +1,5 @@
 import { assert } from 'chai';
-import { encrypt, decrypt, loadAesKey, writeAesKey, generateAesKey, signIT, generateRSAKeyPair, encryptRSA, decryptRSA, getFuncSig, prepareIT, generateECDSAPrivateKey, prepareCompactIT } from './crypto.js';
+import { encrypt, decrypt, loadAesKey, writeAesKey, generateAesKey, signIT, generateRSAKeyPair, encryptRSA, decryptRSA, getFuncSig, prepareIT, generateECDSAPrivateKey, prepareCompactIT256 } from './crypto.js';
 import { block_size, addressSize, funcSigSize, hexBase } from './crypto.js';
 import fs from 'fs';
 import crypto from 'crypto';
@@ -283,13 +283,13 @@ describe('Crypto Tests', () => {
         // Act
         // Generate the signature
         const hash_func = getFuncSig(funcSig);
-        const {ct1, ct2, signature} = prepareCompactIT(plaintext, userKey, sender, contract, hash_func, signingKey);
-
-        const ctHex1 = ct1.toString('hex').padStart(64, '0');
-        const ctHex2 = ct2.toString('hex').padStart(64, '0');
+        const {ct, signature} = prepareCompactIT256(plaintext, userKey, sender, contract, hash_func, signingKey);
+        
+        const ctHex1 = ct.ctHigh.toString('hex').padStart(64, '0');
+        const ctHex2 = ct.ctLow.toString('hex').padStart(64, '0');
         
         // Decrypt the ct and check the decrypted value is equal to the plaintext
-        const decryptedBuffer = decrypt(userKey, ct1.subarray(block_size, ct1.length), ct1.subarray(0, block_size), ct2.subarray(block_size, ct2.length), ct2.subarray(0, block_size));
+        const decryptedBuffer = decrypt(userKey, ct.ctHigh.subarray(block_size, ct.ctHigh.length), ct.ctHigh.subarray(0, block_size), ct.ctLow.subarray(block_size, ct.ctLow.length), ct.ctLow.subarray(0, block_size));
 
         // Convert the plaintext to bytes
         const hexString = plaintext.toString(16).padStart(64, '0');

--- a/python/crypto.py
+++ b/python/crypto.py
@@ -84,11 +84,11 @@ def decrypt(key, r, ciphertext, r2=None, ciphertext2=None):
     plaintext = bytes(x ^ y for x, y in zip(encrypted_r, ciphertext))
 
     if r2 is not None and ciphertext2 is not None:
-        # Encrypt the random value 'r' using AES in ECB mode
-        encrypted_r = cipher.encrypt(r2)
+        # Encrypt the random value 'r2' using AES in ECB mode
+        encrypted_r2 = cipher.encrypt(r2)
 
-        # XOR the encrypted random value 'r' with the ciphertext to obtain the plaintext
-        plaintext2 = bytes(x ^ y for x, y in zip(encrypted_r, ciphertext2))
+        # XOR the encrypted random value 'r2' with the ciphertext2 to obtain the plaintext2
+        plaintext2 = bytes(x ^ y for x, y in zip(encrypted_r2, ciphertext2))
 
         plaintext = plaintext + plaintext2
 
@@ -145,7 +145,7 @@ def validate_input_lengths(sender, addr, func_sig, ct, key):
     if len(func_sig) != func_sig_size:
         raise ValueError(f"Invalid signature size: {len(func_sig)} bytes, must be {func_sig_size} bytes")
     if len(ct) != ct_size and len(ct) != 2*ct_size:
-        raise ValueError(f"Invalid ct length: {len(ct)} bytes, must be {ct_size} bytes in case of 128 bits plaintext or less, or {2*ct_size} bytes in case of 256 bits plaintext or less")
+        raise ValueError(f"Invalid ct length: {len(ct)} bytes, must be {ct_size} bytes in case of 128 bits plaintext or less, or {2*ct_size} bytes in case of plaintext between 128 and 256")
     if len(key) != key_size:
         raise ValueError(f"Invalid key length: {len(key)} bytes, must be {key_size} bytes")
 
@@ -181,12 +181,12 @@ def prepare_compact_IT(plaintext, user_aes_key, sender, contract, func_sig, sign
     # Convert integer back to bytes to check length
     ct_bytes = ct.to_bytes((ct.bit_length() + 7) // 8, 'big')
     
-    if (len(ct_bytes) == 32):
+    if (len(ct_bytes) == ct_size):
         return (ct, signature)
     else:
-        ct1 = ct_bytes[:32]
-        ct2 = ct_bytes[32:]
-        # Convert the ct to an integer
+        ct1 = ct_bytes[:ct_size]
+        ct2 = ct_bytes[ct_size:]
+        # Convert the ct into two integers
         ctInt1 = int.from_bytes(ct1, byteorder='big')
         ctInt2 = int.from_bytes(ct2, byteorder='big')
         return (ctInt1, ctInt2, signature)
@@ -205,18 +205,19 @@ def inner_prepare_IT(plaintext, user_aes_key, sender, contract, func_sig_hash, s
     # Convert the integer to a byte slice with size aligned to 8.
     plaintext_bytes = plaintext.to_bytes((plaintext.bit_length() + 7) // 8, 'big')
 
-    if len(plaintext_bytes) > 32:
+    if len(plaintext_bytes) > block_size*2:
         raise ValueError("Plaintext size must be 256 bits or smaller.")
 
-    if len(plaintext_bytes) <= 16:
+    if len(plaintext_bytes) <= block_size:
         # Encrypt the plaintext with the user's AES key
         ciphertext, r = encrypt(user_aes_key, plaintext_bytes)
         ct = ciphertext + r
     else:
+        padded_plaintext_bytes = bytes(block_size*2 - len(plaintext_bytes)) + plaintext_bytes
         # Encrypt the plaintext with the user's AES key
-        ciphertext1, r1 = encrypt(user_aes_key, plaintext_bytes[:16])
-        ciphertext2, r2 = encrypt(user_aes_key, plaintext_bytes[16:])
-        ct = ciphertext1 + r1 + ciphertext2 + r2
+        ciphertextHigh, rHigh = encrypt(user_aes_key, padded_plaintext_bytes[:block_size])
+        ciphertextLow, rLow = encrypt(user_aes_key, padded_plaintext_bytes[block_size:])
+        ct = ciphertextHigh + rHigh + ciphertextLow + rLow
 
     # Sign the message
     signature = signIT(sender_address_bytes, contract_address_bytes, func_sig_hash, ct, signing_key, eip191)

--- a/python/crypto.py
+++ b/python/crypto.py
@@ -177,18 +177,25 @@ def sign_eip191(message, key):
     signed_message = Account.sign_message(encode_defunct(primitive=message), key)
     return signed_message.signature
 
-def prepare_compact_IT(plaintext, user_aes_key, sender, contract, func_sig, signing_key, eip191=False):
+def prepare_IT(plaintext, user_aes_key, sender, contract, func_sig, signing_key, eip191=False):
     if (plaintext.bit_length() > max_plaintext_bit_size/2):
-        raise ValueError("Plaintext size must be 128 bits or smaller. To prepare a 256 bit plaintext, use prepare_compact_IT256 instead.")
-    
-    ct, signature = prepare_IT(plaintext, user_aes_key, sender, contract, func_sig, signing_key, eip191, False)
-    return (ct, signature)
+        raise ValueError("Plaintext size must be 128 bits or smaller. To prepare a 256 bit plaintext, use prepare_IT_256 instead.")
 
-def prepare_compact_IT_256(plaintext, user_aes_key, sender, contract, func_sig, signing_key, eip191=False):
+    # Create the function signature
+    func_hash = get_func_sig(func_sig)
+
+    return inner_prepare_IT(plaintext, user_aes_key, sender, contract, func_hash, signing_key, eip191, False)
+
+def prepare_IT_256(plaintext, user_aes_key, sender, contract, func_sig, signing_key, eip191=False):
+
     if (plaintext.bit_length() > max_plaintext_bit_size):
         raise ValueError("Plaintext size must be between 128 and 256 bits.")
-    
-    ct, signature = prepare_IT(plaintext, user_aes_key, sender, contract, func_sig, signing_key, eip191, True)
+
+    # Create the function signature
+    func_hash = get_func_sig(func_sig)
+
+    ct, signature =  inner_prepare_IT(plaintext, user_aes_key, sender, contract, func_hash, signing_key, eip191, True)
+
     # Convert integer back to bytes to check length
     ct_bytes = ct.to_bytes((ct.bit_length() + 7) // 8, 'big')
     ctHigh = ct_bytes[:ct_size]
@@ -197,12 +204,6 @@ def prepare_compact_IT_256(plaintext, user_aes_key, sender, contract, func_sig, 
     ctIntHigh = int.from_bytes(ctHigh, byteorder='big')
     ctIntLow = int.from_bytes(ctLow, byteorder='big')
     return ((ctIntHigh, ctIntLow), signature)
-
-def prepare_IT(plaintext, user_aes_key, sender, contract, func_sig, signing_key, eip191=False, is256bit = False):
-    # Create the function signature
-    func_hash = get_func_sig(func_sig)
-
-    return inner_prepare_IT(plaintext, user_aes_key, sender, contract, func_hash, signing_key, eip191, is256bit)
 
 def inner_prepare_IT(plaintext, user_aes_key, sender, contract, func_sig_hash, signing_key, eip191, is256bit):
     # Get addresses as bytes

--- a/python/crypto.py
+++ b/python/crypto.py
@@ -46,7 +46,7 @@ def encrypt(key, plaintext):
 
     return ciphertext, r
 
-def decrypt(key, r, ciphertext):
+def decrypt(key, r, ciphertext, r2=None, ciphertext2=None):
 
     if len(ciphertext) != block_size:
         raise ValueError("Ciphertext size must be 128 bits.")
@@ -59,6 +59,21 @@ def decrypt(key, r, ciphertext):
     if len(r) != block_size:
         raise ValueError("Random size must be 128 bits.")
 
+    # If r2 is not None, then ciphertext2 is required and vice versa
+    # Ensure the sizes of r2 and ciphertext2 are correct
+    if r2 is not None:
+        if len(r2) != block_size:
+            raise ValueError("Random size must be 128 bits.")
+        if ciphertext2 is None:
+            raise ValueError("Ciphertext2 is required.")
+
+    if ciphertext2 is not None:
+        if len(ciphertext2) != block_size:
+            raise ValueError("Ciphertext size must be 128 bits.")
+        
+        if r2 is None:
+            raise ValueError("Random2 is required.")
+
     # Create a new AES cipher block using the provided key
     cipher = AES.new(key, AES.MODE_ECB)
 
@@ -67,6 +82,15 @@ def decrypt(key, r, ciphertext):
 
     # XOR the encrypted random value 'r' with the ciphertext to obtain the plaintext
     plaintext = bytes(x ^ y for x, y in zip(encrypted_r, ciphertext))
+
+    if r2 is not None and ciphertext2 is not None:
+        # Encrypt the random value 'r' using AES in ECB mode
+        encrypted_r = cipher.encrypt(r2)
+
+        # XOR the encrypted random value 'r' with the ciphertext to obtain the plaintext
+        plaintext2 = bytes(x ^ y for x, y in zip(encrypted_r, ciphertext2))
+
+        plaintext = plaintext + plaintext2
 
     return plaintext
 
@@ -120,8 +144,8 @@ def validate_input_lengths(sender, addr, func_sig, ct, key):
         raise ValueError(f"Invalid contract address length: {len(addr)} bytes, must be {address_size} bytes")
     if len(func_sig) != func_sig_size:
         raise ValueError(f"Invalid signature size: {len(func_sig)} bytes, must be {func_sig_size} bytes")
-    if len(ct) != ct_size:
-        raise ValueError(f"Invalid ct length: {len(ct)} bytes, must be {ct_size} bytes")
+    if len(ct) != ct_size and len(ct) != 2*ct_size:
+        raise ValueError(f"Invalid ct length: {len(ct)} bytes, must be {ct_size} bytes in case of 128 bits plaintext or less, or {2*ct_size} bytes in case of 256 bits plaintext or less")
     if len(key) != key_size:
         raise ValueError(f"Invalid key length: {len(key)} bytes, must be {key_size} bytes")
 
@@ -167,9 +191,18 @@ def inner_prepare_IT(plaintext, user_aes_key, sender, contract, func_sig_hash, s
     # Convert the integer to a byte slice with size aligned to 8.
     plaintext_bytes = plaintext.to_bytes((plaintext.bit_length() + 7) // 8, 'big')
 
-    # Encrypt the plaintext with the user's AES key
-    ciphertext, r = encrypt(user_aes_key, plaintext_bytes)
-    ct = ciphertext + r
+    if len(plaintext_bytes) > 32:
+        raise ValueError("Plaintext size must be 256 bits or smaller.")
+
+    if len(plaintext_bytes) <= 16:
+        # Encrypt the plaintext with the user's AES key
+        ciphertext, r = encrypt(user_aes_key, plaintext_bytes)
+        ct = ciphertext + r
+    else:
+        # Encrypt the plaintext with the user's AES key
+        ciphertext1, r1 = encrypt(user_aes_key, plaintext_bytes[:16])
+        ciphertext2, r2 = encrypt(user_aes_key, plaintext_bytes[16:])
+        ct = ciphertext1 + r1 + ciphertext2 + r2
 
     # Sign the message
     signature = signIT(sender_address_bytes, contract_address_bytes, func_sig_hash, ct, signing_key, eip191)

--- a/python/crypto.py
+++ b/python/crypto.py
@@ -176,6 +176,20 @@ def sign_eip191(message, key):
     signed_message = Account.sign_message(encode_defunct(primitive=message), key)
     return signed_message.signature
 
+def prepare_compact_IT(plaintext, user_aes_key, sender, contract, func_sig, signing_key, eip191=False):
+    ct, signature = prepare_IT(plaintext, user_aes_key, sender, contract, func_sig, signing_key, eip191)
+    # Convert integer back to bytes to check length
+    ct_bytes = ct.to_bytes((ct.bit_length() + 7) // 8, 'big')
+    
+    if (len(ct_bytes) == 32):
+        return (ct, signature)
+    else:
+        ct1 = ct_bytes[:32]
+        ct2 = ct_bytes[32:]
+        # Convert the ct to an integer
+        ctInt1 = int.from_bytes(ct1, byteorder='big')
+        ctInt2 = int.from_bytes(ct2, byteorder='big')
+        return (ctInt1, ctInt2, signature)
 
 def prepare_IT(plaintext, user_aes_key, sender, contract, func_sig, signing_key, eip191=False):
     # Create the function signature

--- a/python/crypto.py
+++ b/python/crypto.py
@@ -18,6 +18,7 @@ address_size = 20
 func_sig_size = 4
 ct_size = 32
 key_size = 32
+max_plaintext_bit_size = 256
 
 def encrypt(key, plaintext):
 
@@ -177,27 +178,33 @@ def sign_eip191(message, key):
     return signed_message.signature
 
 def prepare_compact_IT(plaintext, user_aes_key, sender, contract, func_sig, signing_key, eip191=False):
-    ct, signature = prepare_IT(plaintext, user_aes_key, sender, contract, func_sig, signing_key, eip191)
+    if (plaintext.bit_length() > max_plaintext_bit_size/2):
+        raise ValueError("Plaintext size must be 128 bits or smaller. To prepare a 256 bit plaintext, use prepare_compact_IT256 instead.")
+    
+    ct, signature = prepare_IT(plaintext, user_aes_key, sender, contract, func_sig, signing_key, eip191, False)
+    return (ct, signature)
+
+def prepare_compact_IT_256(plaintext, user_aes_key, sender, contract, func_sig, signing_key, eip191=False):
+    if (plaintext.bit_length() > max_plaintext_bit_size):
+        raise ValueError("Plaintext size must be between 128 and 256 bits.")
+    
+    ct, signature = prepare_IT(plaintext, user_aes_key, sender, contract, func_sig, signing_key, eip191, True)
     # Convert integer back to bytes to check length
     ct_bytes = ct.to_bytes((ct.bit_length() + 7) // 8, 'big')
-    
-    if (len(ct_bytes) == ct_size):
-        return (ct, signature)
-    else:
-        ct1 = ct_bytes[:ct_size]
-        ct2 = ct_bytes[ct_size:]
-        # Convert the ct into two integers
-        ctInt1 = int.from_bytes(ct1, byteorder='big')
-        ctInt2 = int.from_bytes(ct2, byteorder='big')
-        return (ctInt1, ctInt2, signature)
+    ctHigh = ct_bytes[:ct_size]
+    ctLow = ct_bytes[ct_size:]
+    # Convert the ct into two integers
+    ctIntHigh = int.from_bytes(ctHigh, byteorder='big')
+    ctIntLow = int.from_bytes(ctLow, byteorder='big')
+    return ((ctIntHigh, ctIntLow), signature)
 
-def prepare_IT(plaintext, user_aes_key, sender, contract, func_sig, signing_key, eip191=False):
+def prepare_IT(plaintext, user_aes_key, sender, contract, func_sig, signing_key, eip191=False, is256bit = False):
     # Create the function signature
     func_hash = get_func_sig(func_sig)
 
-    return inner_prepare_IT(plaintext, user_aes_key, sender, contract, func_hash, signing_key, eip191)
+    return inner_prepare_IT(plaintext, user_aes_key, sender, contract, func_hash, signing_key, eip191, is256bit)
 
-def inner_prepare_IT(plaintext, user_aes_key, sender, contract, func_sig_hash, signing_key, eip191):
+def inner_prepare_IT(plaintext, user_aes_key, sender, contract, func_sig_hash, signing_key, eip191, is256bit):
     # Get addresses as bytes
     sender_address_bytes = bytes.fromhex(sender.address[2:])
     contract_address_bytes = bytes.fromhex(contract.address[2:])
@@ -211,7 +218,13 @@ def inner_prepare_IT(plaintext, user_aes_key, sender, contract, func_sig_hash, s
     if len(plaintext_bytes) <= block_size:
         # Encrypt the plaintext with the user's AES key
         ciphertext, r = encrypt(user_aes_key, plaintext_bytes)
-        ct = ciphertext + r
+        if (is256bit):
+            zero = 0
+            zero_bytes = zero.to_bytes((zero.bit_length() + 7) // 8, 'big')
+            ciphertextHigh, rHigh = encrypt(user_aes_key, zero_bytes)
+            ct = ciphertextHigh + rHigh + ciphertext + r
+        else:
+            ct = ciphertext + r
     else:
         padded_plaintext_bytes = bytes(block_size*2 - len(plaintext_bytes)) + plaintext_bytes
         # Encrypt the plaintext with the user's AES key

--- a/python/test.py
+++ b/python/test.py
@@ -3,7 +3,7 @@ import tempfile
 import os
 from Crypto.Cipher import AES
 from Crypto.Random import get_random_bytes
-from crypto import encrypt, decrypt, load_aes_key, write_aes_key, generate_aes_key, signIT, generate_rsa_keypair, encrypt_rsa, decrypt_rsa, get_func_sig, prepare_IT, generate_ECDSA_private_key
+from crypto import encrypt, decrypt, load_aes_key, write_aes_key, generate_aes_key, signIT, generate_rsa_keypair, encrypt_rsa, decrypt_rsa, get_func_sig, prepare_IT, generate_ECDSA_private_key, prepare_compact_IT
 from crypto import block_size, address_size, func_sig_size, key_size
 from eth_keys import keys
 from web3 import Account
@@ -271,11 +271,12 @@ class TestMpcHelper(unittest.TestCase):
 
         # Act
         # Call the sign function
-        ct, _ = prepare_IT(plaintext, userKey, sender, contract, func_sig, signingKey)
+        (ct1, ct2, _) = prepare_compact_IT(plaintext, userKey, sender, contract, func_sig, signingKey)
         # Convert the integer to a byte slice with size aligned to 8.
-        ctBytes = ct.to_bytes((ct.bit_length() + 7) // 8, 'big')
+        ct1Bytes = ct1.to_bytes((ct1.bit_length() + 7) // 8, 'big')
+        ct2Bytes = ct2.to_bytes((ct2.bit_length() + 7) // 8, 'big')
 
-        decrypted = decrypt(userKey, ctBytes[block_size:2*block_size], ctBytes[:block_size], ctBytes[3*block_size:], ctBytes[2*block_size:3*block_size])
+        decrypted = decrypt(userKey, ct1Bytes[block_size:2*block_size], ct1Bytes[:block_size], ct2Bytes[block_size:2*block_size], ct2Bytes[:block_size])
         decrypted_integer = int.from_bytes(decrypted, 'big')
         self.assertEqual(plaintext, decrypted_integer)
 

--- a/python/test.py
+++ b/python/test.py
@@ -3,7 +3,7 @@ import tempfile
 import os
 from Crypto.Cipher import AES
 from Crypto.Random import get_random_bytes
-from crypto import encrypt, decrypt, load_aes_key, write_aes_key, generate_aes_key, signIT, generate_rsa_keypair, encrypt_rsa, decrypt_rsa, get_func_sig, prepare_IT, generate_ECDSA_private_key, prepare_compact_IT_256
+from crypto import encrypt, decrypt, load_aes_key, write_aes_key, generate_aes_key, signIT, generate_rsa_keypair, encrypt_rsa, decrypt_rsa, get_func_sig, prepare_IT, generate_ECDSA_private_key, prepare_IT_256
 from crypto import block_size, address_size, func_sig_size, key_size
 from eth_keys import keys
 from web3 import Account
@@ -271,7 +271,7 @@ class TestMpcHelper(unittest.TestCase):
 
         # Act
         # Call the sign function
-        (ct, _) = prepare_compact_IT_256(plaintext, userKey, sender, contract, func_sig, signingKey)
+        (ct, _) = prepare_IT_256(plaintext, userKey, sender, contract, func_sig, signingKey)
         ctHigh, ctLow = ct
         # Convert the integer to a byte slice with size aligned to 8.
         ct1Bytes = ctHigh.to_bytes((ctHigh.bit_length() + 7) // 8, 'big')

--- a/python/test.py
+++ b/python/test.py
@@ -3,7 +3,7 @@ import tempfile
 import os
 from Crypto.Cipher import AES
 from Crypto.Random import get_random_bytes
-from crypto import encrypt, decrypt, load_aes_key, write_aes_key, generate_aes_key, signIT, generate_rsa_keypair, encrypt_rsa, decrypt_rsa, get_func_sig, prepare_IT, generate_ECDSA_private_key, prepare_compact_IT
+from crypto import encrypt, decrypt, load_aes_key, write_aes_key, generate_aes_key, signIT, generate_rsa_keypair, encrypt_rsa, decrypt_rsa, get_func_sig, prepare_IT, generate_ECDSA_private_key, prepare_compact_IT_256
 from crypto import block_size, address_size, func_sig_size, key_size
 from eth_keys import keys
 from web3 import Account
@@ -271,10 +271,11 @@ class TestMpcHelper(unittest.TestCase):
 
         # Act
         # Call the sign function
-        (ct1, ct2, _) = prepare_compact_IT(plaintext, userKey, sender, contract, func_sig, signingKey)
+        (ct, _) = prepare_compact_IT_256(plaintext, userKey, sender, contract, func_sig, signingKey)
+        ctHigh, ctLow = ct
         # Convert the integer to a byte slice with size aligned to 8.
-        ct1Bytes = ct1.to_bytes((ct1.bit_length() + 7) // 8, 'big')
-        ct2Bytes = ct2.to_bytes((ct2.bit_length() + 7) // 8, 'big')
+        ct1Bytes = ctHigh.to_bytes((ctHigh.bit_length() + 7) // 8, 'big')
+        ct2Bytes = ctLow.to_bytes((ctLow.bit_length() + 7) // 8, 'big')
 
         decrypted = decrypt(userKey, ct1Bytes[block_size:2*block_size], ct1Bytes[:block_size], ct2Bytes[block_size:2*block_size], ct2Bytes[:block_size])
         decrypted_integer = int.from_bytes(decrypted, 'big')

--- a/python/test.py
+++ b/python/test.py
@@ -257,6 +257,28 @@ class TestMpcHelper(unittest.TestCase):
         decrypted_integer = int.from_bytes(decrypted, 'big')
         self.assertEqual(plaintext, decrypted_integer)
 
+    def test_prepareIT_256(self):
+        # Arrange
+        plaintext = 1809251394333065553493296640760748560207343510400633813116524750123642650623
+        userKey = bytes.fromhex("b3c3fe73c1bb91862b166a29fe1d63e9")
+        # Create an account object manually
+        sender = Account()
+        sender.address = "0xd67fe7792f18fbd663e29818334a050240887c28"
+        contract = Account()
+        contract.address = "0x69413851f025306dbe12c48ff2225016fc5bbe1b"
+        func_sig = "test(bytes)"
+        signingKey = bytes.fromhex("3840f44be5805af188e9b42dda56eb99eefc88d7a6db751017ff16d0c5f8143e")
+
+        # Act
+        # Call the sign function
+        ct, _ = prepare_IT(plaintext, userKey, sender, contract, func_sig, signingKey)
+        # Convert the integer to a byte slice with size aligned to 8.
+        ctBytes = ct.to_bytes((ct.bit_length() + 7) // 8, 'big')
+
+        decrypted = decrypt(userKey, ctBytes[block_size:2*block_size], ctBytes[:block_size], ctBytes[3*block_size:], ctBytes[2*block_size:3*block_size])
+        decrypted_integer = int.from_bytes(decrypted, 'big')
+        self.assertEqual(plaintext, decrypted_integer)
+
     def test_rsa_encryption(self):
         # Arrange
         plaintext = b"hello world"
@@ -270,6 +292,8 @@ class TestMpcHelper(unittest.TestCase):
             f.write(private_key.hex())
             f.write("\n")
             f.write(public_key.hex())
+            f.write("\n")
+            f.write(ciphertext.hex())
 
         decrypted = decrypt_rsa(private_key, ciphertext)
 

--- a/testAll.sh
+++ b/testAll.sh
@@ -7,7 +7,7 @@ print_blue() {
 
 print_blue "Running javascript tests..."
 cd js
-npx mocha --require esm --grep "^(?!.*should decrypt a message using RSA scheme$)" test.mjs
+npx mocha --fgrep "should decrypt a message using RSA scheme" --invert test.mjs
 cd ..
 
 print_blue "Running python tests..."
@@ -23,7 +23,7 @@ cd ..
 
 print_blue "Running javascript decrypt test..."
 cd js
-npx mocha --require esm --grep "should decrypt a message using RSA scheme" test.mjs
+npx mocha --grep "should decrypt a message using RSA scheme" test.mjs
 cd ..
 
 print_blue "Running python decrypt test..."


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add 256-bit plaintext encryption support across JavaScript and Python

- Implement `prepareCompactIT` function for handling larger plaintexts

- Update decrypt functions to handle dual ciphertext blocks

- Modify validation logic for variable ciphertext sizes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["128-bit plaintext"] --> B["Single AES block encryption"]
  C["256-bit plaintext"] --> D["Dual AES block encryption"]
  B --> E["Standard IT preparation"]
  D --> F["Compact IT preparation"]
  E --> G["Single ciphertext output"]
  F --> H["Dual ciphertext output"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>crypto_test.go</strong><dd><code>Relax hex string validation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

golang_cli/crypto/crypto_test.go

- Change hex string validation from exact count to minimum count


</details>


  </td>
  <td><a href="https://github.com/soda-mpc/soda-sdk/pull/37/files#diff-dd414c60c1ebd07f3f75bf0772b043c0474efc93b19455632aca10bcc5fd458f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>crypto.js</strong><dd><code>Implement 256-bit encryption support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

js/crypto.js

<ul><li>Add optional <code>r2</code> and <code>ciphertext2</code> parameters to <code>decrypt</code> function<br> <li> Implement dual-block decryption for 256-bit plaintexts<br> <li> Add <code>prepareCompactIT</code> function for handling larger plaintexts<br> <li> Update <code>prepareIT</code> to support both 128-bit and 256-bit plaintexts<br> <li> Modify ciphertext size validation to accept dual sizes</ul>


</details>


  </td>
  <td><a href="https://github.com/soda-mpc/soda-sdk/pull/37/files#diff-593c4e21b5d1f0a7508bb9095f6cb48d79c2e364b2836d831d5124e3755c6ad0">+93/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>crypto.py</strong><dd><code>Add 256-bit plaintext encryption capabilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/crypto.py

<ul><li>Add optional <code>r2</code> and <code>ciphertext2</code> parameters to <code>decrypt</code> function<br> <li> Implement dual-block decryption logic<br> <li> Add <code>prepare_compact_IT</code> function for compact representation<br> <li> Update <code>inner_prepare_IT</code> to handle variable plaintext sizes<br> <li> Modify ciphertext length validation</ul>


</details>


  </td>
  <td><a href="https://github.com/soda-mpc/soda-sdk/pull/37/files#diff-aeef05cdc28ddb53412faead51702c81b1ff0b821450c1891a160f44d6873bc1">+53/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test.py</strong><dd><code>Add 256-bit encryption test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/test.py

<ul><li>Import <code>prepare_compact_IT</code> function<br> <li> Add <code>test_prepareIT_256</code> test case for 256-bit plaintext<br> <li> Update RSA test to write ciphertext to file</ul>


</details>


  </td>
  <td><a href="https://github.com/soda-mpc/soda-sdk/pull/37/files#diff-97691c4be6d2cc527eab537a6b4024dff524a2f746c39164397198e4a70be445">+26/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test.mjs</strong><dd><code>Add 256-bit encryption test cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

js/test.mjs

<ul><li>Import <code>prepareCompactIT</code> function<br> <li> Add test case for 256-bit plaintext preparation<br> <li> Update RSA test to include ciphertext in output file</ul>


</details>


  </td>
  <td><a href="https://github.com/soda-mpc/soda-sdk/pull/37/files#diff-65f4db482cfc04391a5146699b143f8f0dc62637652cf3431a0a125e652321f5">+35/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>testAll.sh</strong><dd><code>Update test execution commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

testAll.sh

<ul><li>Replace <code>--require esm</code> with <code>--fgrep</code> and <code>--invert</code> flags<br> <li> Update mocha command syntax for test filtering</ul>


</details>


  </td>
  <td><a href="https://github.com/soda-mpc/soda-sdk/pull/37/files#diff-20fed710e7532afac92a8388525c132b0b66fdc891ece353eff09a19f10af44f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test.yml</strong><dd><code>Update CI test workflow commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/test.yml

<ul><li>Remove <code>--require esm</code> flag from mocha commands<br> <li> Update test filtering syntax to use <code>--fgrep</code> and <code>--invert</code></ul>


</details>


  </td>
  <td><a href="https://github.com/soda-mpc/soda-sdk/pull/37/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

