### PR TITLE
Adding 128/256 bit support

### DIFF
--- a/golang_cli/crypto/crypto_test.go
+++ b/golang_cli/crypto/crypto_test.go
@@ -355,7 +355,7 @@ func readTwoHexStringsFromFile(path string) ([]byte, []byte, error) {
 	hexStrings := bytes.Split(data, []byte("\n"))
 
 	// Convert the hex strings to bytes
-	if len(hexStrings) != 2 {
+	if len(hexStrings) < 2 {
 		return nil, nil, fmt.Errorf("Expected two hex strings in the file")
 	}
 

--- a/golang_cli/crypto/crypto_test.go
+++ b/golang_cli/crypto/crypto_test.go
@@ -175,11 +175,11 @@ func TestSignature(t *testing.T) {
 	// Arrange
 	sender := make([]byte, AddressSize)
 	_, err := rand.Read(sender)
+	require.NoError(t, err, "Failed to generate random key")
 	addr := make([]byte, AddressSize)
 	_, err = rand.Read(addr)
-
+	require.NoError(t, err, "Failed to generate random address")
 	key := GenerateECDSAPrivateKey()
-	require.NoError(t, err, "Failed to generate random key")
 
 	// Create plaintext with the value 100 as a big integer with less than 128 bits
 	plaintextValue := big.NewInt(100)
@@ -296,17 +296,21 @@ func TestIT(t *testing.T) {
 	// Reading from file simulates the communication between the evm (golang) and the user (python/js)
 	pythonCt, pythonSignature, err := readTwoHexStringsFromFile("../../python/soda_python_sdk/test_pythonIT.txt")
 	require.NoError(t, err, "Read file should not return an error")
-	checkIT(t, plaintextBytes, userKey, contract.Bytes(), ct.Bytes(), pythonCt, pythonSignature)
+	checkIT(t, plaintextBytes, userKey, sender.Bytes(), contract.Bytes(), pythonCt, pythonSignature)
 	err = os.Remove("../../python/soda_python_sdk/test_pythonIT.txt")
+	require.NoError(t, err, "Delete file should not return an error")
 
 	jsCt, jsSignature, err := readTwoHexStringsFromFile("../../js/test_jsIT.txt")
-	tsCt, tsSignature, err := readTwoHexStringsFromFile("../../ts/test_tsIT.txt")
-
 	require.NoError(t, err, "Read file should not return an error")
-	checkIT(t, plaintextBytes, userKey, contract.Bytes(), ct.Bytes(), jsCt, jsSignature)
-	checkIT(t, plaintextBytes, userKey, contract.Bytes(), ct.Bytes(), tsCt, tsSignature)
+	tsCt, tsSignature, err := readTwoHexStringsFromFile("../../ts/test_tsIT.txt")
+	require.NoError(t, err, "Read file should not return an error")
+
+	checkIT(t, plaintextBytes, userKey, sender.Bytes(), contract.Bytes(), jsCt, jsSignature)
+	checkIT(t, plaintextBytes, userKey, sender.Bytes(), contract.Bytes(), tsCt, tsSignature)
 	err = os.Remove("../../js/test_jsIT.txt")
+	require.NoError(t, err, "Delete file should not return an error")
 	err = os.Remove("../../ts/test_tsIT.txt")
+	require.NoError(t, err, "Delete file should not return an error")
 }
 
 func checkIT(t *testing.T, plaintext, userKey, sender, addr, ct, signature []byte) {
@@ -440,6 +444,7 @@ func checkFunctionSignature(t *testing.T, filePath string, expected []byte) {
 	require.NoError(t, err, "Read python value should not return an error")
 	assert.Equal(t, expected, val, "hashed values should match")
 	err = os.Remove(filePath)
+	require.NoError(t, err, "Delete file should not return an error")
 }
 
 func TestGetFuncSig(t *testing.T) {

--- a/js/crypto.mjs
+++ b/js/crypto.mjs
@@ -11,6 +11,7 @@ export const ADDRESS_SIZE = 20; // 160-bit is the output of the Keccak-256 algor
 export const CT_SIZE = 32;
 export const KEY_SIZE = 32;
 export const HEX_BASE = 16;
+export const maxPlaintextBitSize = 256;
 
 export function encrypt(key, plaintext) {
     
@@ -44,7 +45,7 @@ export function encrypt(key, plaintext) {
     return { ciphertext, r: Buffer.from(uint8ArrayR) };
 }
 
-export function decrypt(key, r, ciphertext) {
+export function decrypt(key, r, ciphertext, r2=null, ciphertext2=null) {
 
     if (ciphertext.length !== BLOCK_SIZE) {
         throw new RangeError("Ciphertext size must be 128 bits.");
@@ -52,22 +53,54 @@ export function decrypt(key, r, ciphertext) {
 
     // Ensure key size is 128 bits (16 bytes)
     if (key.length !== BLOCK_SIZE) {
-        throw new RangeError("Key size must be 128 bits.");
+        throw new RangeError("Key size must be 128 bits, received " + key.length + " bytes.");
     }
 
     // Ensure random size is 128 bits (16 bytes)
     if (r.length !== BLOCK_SIZE) {
-        throw new RangeError("Random size must be 128 bits.");
+        throw new RangeError("Random size must be 128 bits, received " + r.length + " bytes.");
+    }
+
+    if (r2 !== null) {
+        if (r2.length !== BLOCK_SIZE) {
+            throw new RangeError("Random2 size must be 128 bits, received " + r2.length + " bytes.");
+        }
+        if (ciphertext2 === null) {
+            throw new RangeError("Ciphertext2 is required.");
+        }
+    }
+
+    if (ciphertext2 !== null) {
+        if (ciphertext2.length !== BLOCK_SIZE) {
+            throw new RangeError("Ciphertext2 size must be 128 bits, received " + ciphertext2.length + " bytes.");
+        }
+
+        if (r2 === null) {
+            throw new RangeError("Random2 is required.");
+        }
     }
 
    // Get the encrypted random value 'r'
     const encryptedR = encryptNumber(r, key)
 
     // XOR the encrypted random value 'r' with the ciphertext to obtain the plaintext
-    const plaintext = new Uint8Array(BLOCK_SIZE)
+    let plaintext = new Uint8Array(BLOCK_SIZE)
 
     for (let i = 0; i < encryptedR.length; i++) {
         plaintext[i] = encryptedR[i] ^ ciphertext[i]
+    }
+
+    if (r2 !== null && ciphertext2 !== null) {
+        // Encrypt the random value 'r' using AES in ECB mode
+        const encryptedR2 = encryptNumber(r2, key)
+
+        // XOR the encrypted random value 'r' with the ciphertext to obtain the plaintext
+        const plaintext2 = Buffer.alloc(encryptedR2.length);
+        for (let i = 0; i < encryptedR2.length; i++) {
+            plaintext2[i] = encryptedR2[i] ^ ciphertext2[i];
+        }
+
+        plaintext = Buffer.concat([plaintext, plaintext2]);
     }
 
     return plaintext
@@ -131,8 +164,8 @@ export function signIT(sender, addr, ct, key, eip191=false) {
     if (addr.length !== ADDRESS_SIZE) {
         throw new RangeError(`Invalid contract address length: ${addr.length} bytes, must be ${ADDRESS_SIZE} bytes`);
     }
-    if (ct.length !== CT_SIZE) {
-        throw new RangeError(`Invalid ct length: ${ct.length} bytes, must be ${CT_SIZE} bytes`);
+    if (ct.length !== CT_SIZE && ct.length !== 2*CT_SIZE) {
+        throw new RangeError(`Invalid ct length: ${ct.length} bytes, must be ${CT_SIZE} bytes in case of 128 bits plaintext or less, or ${2*CT_SIZE} bytes in case of 256 bits plaintext or less`);
     }
     // Ensure the key is the correct length
     if (key.length !== KEY_SIZE) {
@@ -222,15 +255,35 @@ export function prepareMessage(plaintext, signerAddress, aesKey, contractAddress
     return { encryptedInt, message };
 }
 
+function writeBigUInt128BE(buffer, value, offset = 0) {
+    const hexString = value.toString(HEX_BASE).padStart(CT_SIZE, '0');
+    const bytes = Buffer.from(hexString, 'hex');
+    bytes.copy(buffer, offset);
+}
+
+export function writeBigUInt256BE(buffer, value, offset = 0) {
+    const hexString = value.toString(HEX_BASE).padStart(CT_SIZE*2, '0');
+    const bytes = Buffer.from(hexString, 'hex');
+    if (buffer.length > bytes.length) {
+        offset = buffer.length - bytes.length;
+    }
+    bytes.copy(buffer, offset);
+}
+
 export function prepareIT(plaintext, userAesKey, sender, contract, signingKey, eip191=false) {
 
     // Get the bytes of the sender, contract, and function signature
     const senderBytes = toBuffer(sender)
     const contractBytes = toBuffer(contract)
 
-    // Convert the plaintext to bytes
-    const plaintextBytes = Buffer.alloc(8); // Allocate a buffer of size 8 bytes
-    plaintextBytes.writeBigUInt64BE(BigInt(plaintext)); // Write the uint64 value to the buffer as little-endian
+    const plaintextBigInt = BigInt(plaintext);
+    const bitSize = plaintextBigInt.toString(2).length;
+    if (bitSize > maxPlaintextBitSize/2) {
+        throw new RangeError("Plaintext size must be 128 bits or smaller. To prepare a 256 bit plaintext, use prepareIT256 instead.");
+    }
+
+    const plaintextBytes = Buffer.alloc(BLOCK_SIZE); // Allocate a buffer of size 16 bytes
+    writeBigUInt128BE(plaintextBytes, plaintextBigInt); // Write the uint128 value to the buffer as big-endian
 
     // Encrypt the plaintext using AES key
     const { ciphertext, r } = encrypt(userAesKey, plaintextBytes);
@@ -243,6 +296,65 @@ export function prepareIT(plaintext, userAesKey, sender, contract, signingKey, e
     const ctInt = BigInt('0x' + ct.toString('hex'));
 
     return { ctInt, signature };
+}
+
+export function prepareIT256(plaintext, userAesKey, sender, contract, signingKey, eip191=false, is256bit=false) {
+
+    // Get the bytes of the sender, contract, and function signature
+    const senderBytes = toBuffer(sender)
+    const contractBytes = toBuffer(contract)
+
+    // Convert the plaintext to bytes
+    const plaintextBigInt = BigInt(plaintext);
+    const bitSize = plaintextBigInt.toString(2).length;
+    if (bitSize > maxPlaintextBitSize) {
+        throw new RangeError("Plaintext size must be between 128 and 256 bits.");
+    }
+
+    let ct;
+
+    // In case of 128 bits plaintext, encrypt it as the low part of the ct, and then encrypt the high part of the ct with zeros
+    if (bitSize <= maxPlaintextBitSize/2) {
+        const plaintextBytes = Buffer.alloc(BLOCK_SIZE); // Allocate a buffer of size 16 bytes
+        writeBigUInt128BE(plaintextBytes, plaintextBigInt); // Write the uint128 value to the buffer as big-endian
+        // Encrypt the plaintext using AES key
+        const {ciphertext, r} = encrypt(userAesKey, plaintextBytes);
+
+        // Encrypt the high part of the ct with zeros
+        const zero = BigInt(0);
+        const zeroBytes = Buffer.alloc(BLOCK_SIZE);
+        writeBigUInt128BE(zeroBytes, zero);
+        const {ciphertext: ciphertextHigh, r: rHigh} = encrypt(userAesKey, zeroBytes);
+        ct = Buffer.concat([ciphertextHigh, rHigh, ciphertext, r]);
+
+    } else if (bitSize <= maxPlaintextBitSize) {
+        const plaintextBytes = Buffer.alloc(CT_SIZE); // Allocate a buffer of size 32 bytes
+        writeBigUInt256BE(plaintextBytes, plaintextBigInt); // Write the uint256 value to the buffer as big-endian
+
+        // Encrypt each part of the plaintext using AES key
+        const resultHigh = encrypt(userAesKey, plaintextBytes.slice(0, BLOCK_SIZE));
+        const resultLow = encrypt(userAesKey, plaintextBytes.slice(BLOCK_SIZE));
+
+        // Now destructure
+        const { ciphertext: ciphertextHigh, r: rHigh } = resultHigh;
+        const { ciphertext: ciphertextLow, r: rLow } = resultLow;
+
+        ct = Buffer.concat([ciphertextHigh, rHigh, ciphertextLow, rLow]);
+    } else if (bitSize > maxPlaintextBitSize) {
+        throw new RangeError("Plaintext size must be 256 bits or smaller.");
+    }
+
+    // Sign the message
+    const signature = signIT(senderBytes, contractBytes, ct, signingKey, eip191);
+
+    const ciphertextHigh = ct.slice(0, CT_SIZE);
+    const ciphertextLow = ct.slice(CT_SIZE);
+
+    // Convert Buffer to uint256 (BigInt) for Solidity compatibility
+    const ciphertextHighUint = BigInt('0x' + ciphertextHigh.toString('hex'));
+    const ciphertextLowUint = BigInt('0x' + ciphertextLow.toString('hex'));
+
+    return { ciphertext: {ciphertextHigh: ciphertextHighUint, ciphertextLow: ciphertextLowUint}, signature };
 }
 
 export function generateRSAKeyPair(){

--- a/js/crypto.mjs
+++ b/js/crypto.mjs
@@ -95,7 +95,7 @@ export function decrypt(key, r, ciphertext, r2=null, ciphertext2=null) {
         const encryptedR2 = encryptNumber(r2, key)
 
         // XOR the encrypted random value 'r' with the ciphertext to obtain the plaintext
-        const plaintext2 = Buffer.alloc(encryptedR2.length);
+        const plaintext2 = Buffer.alloc(BLOCK_SIZE);
         for (let i = 0; i < encryptedR2.length; i++) {
             plaintext2[i] = encryptedR2[i] ^ ciphertext2[i];
         }

--- a/js/test.mjs
+++ b/js/test.mjs
@@ -6,12 +6,14 @@ import {
     generateECDSAPrivateKey, generateRSAKeyPair,
     getFuncSig,
     prepareIT, prepareMessage,
-    signIT
+    signIT,
+    prepareIT256, 
+    writeBigUInt256BE
 } from './crypto.mjs';
 
 import { writeAesKey, loadAesKey } from './utils.mjs';
 
-import { BLOCK_SIZE, ADDRESS_SIZE, HEX_BASE } from './crypto.mjs';
+import { BLOCK_SIZE, ADDRESS_SIZE, HEX_BASE, CT_SIZE } from './crypto.mjs';
 import fs from 'fs';
 import crypto from 'crypto';
 import ethereumjsUtil, {hashPersonalMessage} from 'ethereumjs-util';
@@ -308,6 +310,35 @@ describe('Crypto Tests', () => {
         const plaintextBytes = Buffer.from(hexString, 'hex'); 
         // Assert
         assert.deepStrictEqual(plaintextBytes, decryptedBuffer.subarray(decryptedBuffer.length - plaintextBytes.length, decryptedBuffer.length));
+    });
+
+    // Test case for verify signature
+    it('should prepare IT 256 bits using fixed data', () => {
+        // Arrange
+        // Simulate the generation of random bytes
+        const plaintext = BigInt("34028236692093846346337460743176821145600");
+        const userKey = Buffer.from('b3c3fe73c1bb91862b166a29fe1d63e9', 'hex');;
+        const sender = new ethereumjsUtil.Address(ethereumjsUtil.toBuffer(Buffer.from('d67fe7792f18fbd663e29818334a050240887c28', 'hex')));
+        const contract = new ethereumjsUtil.Address(ethereumjsUtil.toBuffer(Buffer.from('69413851f025306dbe12c48ff2225016fc5bbe1b', 'hex')));
+        const signingKey = Buffer.from('3840f44be5805af188e9b42dda56eb99eefc88d7a6db751017ff16d0c5f8143e', 'hex');
+
+        // Act
+        // Generate the signature
+        const {ciphertext, signature} = prepareIT256(plaintext, userKey, sender, contract, signingKey);
+
+        const ctHighBytes = Buffer.alloc(CT_SIZE); // Allocate a buffer of size 32 bytes
+        writeBigUInt256BE(ctHighBytes, ciphertext.ciphertextHigh); // Write the uint256 value to the buffer as big-endian
+        const ctLowBytes = Buffer.alloc(CT_SIZE); // Allocate a buffer of size 32 bytes
+        writeBigUInt256BE(ctLowBytes, ciphertext.ciphertextLow); // Write the uint256 value to the buffer as big-endian
+        // Decrypt the ct and check the decrypted value is equal to the plaintext
+        const decryptedBuffer = decrypt(userKey, ctHighBytes.subarray(BLOCK_SIZE, ctHighBytes.length), ctHighBytes.subarray(0, BLOCK_SIZE), ctLowBytes.subarray(BLOCK_SIZE, ctLowBytes.length), ctLowBytes.subarray(0, BLOCK_SIZE));
+
+        // Convert the plaintext to bytes
+        const hexString = plaintext.toString(16).padStart(64, '0');
+        const plaintextBytes = Buffer.from(hexString, 'hex'); 
+
+        // Assert
+        assert.deepStrictEqual(plaintextBytes, decryptedBuffer);
     });
 
     // Test case for test rsa encryption scheme

--- a/python/soda_python_sdk/crypto.py
+++ b/python/soda_python_sdk/crypto.py
@@ -16,7 +16,7 @@ ADDRESS_SIZE = 20
 FUNC_SIG_SIZE = 4
 CT_SIZE = 32
 KEY_SIZE = 32
-
+MAX_PLAINTEXT_BIT_SIZE = 256
 
 def encrypt(key, plaintext):
 
@@ -45,7 +45,7 @@ def encrypt(key, plaintext):
 
     return ciphertext, r
 
-def decrypt(key, r, ciphertext):
+def decrypt(key, r, ciphertext, r2=None, ciphertext2=None):
 
     if len(ciphertext) != BLOCK_SIZE:
         raise ValueError("Ciphertext size must be 128 bits.")
@@ -58,6 +58,21 @@ def decrypt(key, r, ciphertext):
     if len(r) != BLOCK_SIZE:
         raise ValueError("Random size must be 128 bits.")
 
+     # If r2 is not None, then ciphertext2 is required and vice versa
+    # Ensure the sizes of r2 and ciphertext2 are correct
+    if r2 is not None:
+        if len(r2) != BLOCK_SIZE:
+            raise ValueError("Random size must be 128 bits.")
+        if ciphertext2 is None:
+            raise ValueError("Ciphertext2 is required.")
+
+    if ciphertext2 is not None:
+        if len(ciphertext2) != BLOCK_SIZE:
+            raise ValueError("Ciphertext size must be 128 bits.")
+
+        if r2 is None:
+            raise ValueError("Random2 is required.")
+
     # Create a new AES cipher block using the provided key
     cipher = AES.new(key, AES.MODE_ECB)
 
@@ -66,6 +81,15 @@ def decrypt(key, r, ciphertext):
 
     # XOR the encrypted random value 'r' with the ciphertext to obtain the plaintext
     plaintext = bytes(x ^ y for x, y in zip(encrypted_r, ciphertext))
+
+    if r2 is not None and ciphertext2 is not None:
+        # Encrypt the random value 'r2' using AES in ECB mode
+        encrypted_r2 = cipher.encrypt(r2)
+
+        # XOR the encrypted random value 'r2' with the ciphertext2 to obtain the plaintext2
+        plaintext2 = bytes(x ^ y for x, y in zip(encrypted_r2, ciphertext2))
+
+        plaintext = plaintext + plaintext2
 
     return plaintext
 
@@ -117,8 +141,8 @@ def validate_input_lengths(sender, addr, ct, key):
         raise ValueError(f"Invalid sender address length: {len(sender)} bytes, must be {ADDRESS_SIZE} bytes")
     if len(addr) != ADDRESS_SIZE:
         raise ValueError(f"Invalid contract address length: {len(addr)} bytes, must be {ADDRESS_SIZE} bytes")
-    if len(ct) != CT_SIZE:
-        raise ValueError(f"Invalid ct length: {len(ct)} bytes, must be {CT_SIZE} bytes")
+    if len(ct) != CT_SIZE and len(ct) != 2*CT_SIZE:
+        raise ValueError(f"Invalid ct length: {len(ct)} bytes, must be {CT_SIZE} bytes in case of 128 bits plaintext or less, or {2*CT_SIZE} bytes in case of 256 bits plaintext or less")
     if len(key) != KEY_SIZE:
         raise ValueError(f"Invalid key length: {len(key)} bytes, must be {KEY_SIZE} bytes")
 
@@ -152,6 +176,29 @@ def sign_eip191(message, key):
 
 def prepare_IT(plaintext, user_aes_key, sender, contract, signing_key, eip191=False):
 
+    if (plaintext.bit_length() > MAX_PLAINTEXT_BIT_SIZE/2):
+        raise ValueError("Plaintext size must be 128 bits or smaller. To prepare a 256 bit plaintext, use prepare_IT_256 instead.")
+
+    return inner_prepare_IT(plaintext, user_aes_key, sender, contract, signing_key, eip191, False)
+
+def prepare_IT_256(plaintext, user_aes_key, sender, contract, signing_key, eip191=False):
+
+    if (plaintext.bit_length() > MAX_PLAINTEXT_BIT_SIZE):
+        raise ValueError("Plaintext size must be between 128 and 256 bits.")
+
+    # Create the function signature
+    ct, signature =  inner_prepare_IT(plaintext, user_aes_key, sender, contract, signing_key, eip191, True)
+
+    # Convert integer back to bytes to check length
+    ct_bytes = ct.to_bytes((ct.bit_length() + 7) // 8, 'big')
+    ctHigh = ct_bytes[:CT_SIZE]
+    ctLow = ct_bytes[CT_SIZE:]
+    # Convert the ct into two integers
+    ctIntHigh = int.from_bytes(ctHigh, byteorder='big')
+    ctIntLow = int.from_bytes(ctLow, byteorder='big')
+    return ((ctIntHigh, ctIntLow), signature)
+
+def inner_prepare_IT(plaintext, user_aes_key, sender, contract, signing_key, eip191, is256bit):
     # Get addresses as bytes
     sender_address_bytes = bytes.fromhex(sender.address[2:])
     contract_address_bytes = bytes.fromhex(contract.address[2:])
@@ -159,9 +206,25 @@ def prepare_IT(plaintext, user_aes_key, sender, contract, signing_key, eip191=Fa
     # Convert the integer to a byte slice with size aligned to 8.
     plaintext_bytes = plaintext.to_bytes((plaintext.bit_length() + 7) // 8, 'big')
 
-    # Encrypt the plaintext with the user's AES key
-    ciphertext, r = encrypt(user_aes_key, plaintext_bytes)
-    ct = ciphertext + r
+    if len(plaintext_bytes) > BLOCK_SIZE*2:
+        raise ValueError("Plaintext size must be 256 bits or smaller.")
+
+    if len(plaintext_bytes) <= BLOCK_SIZE:
+        # Encrypt the plaintext with the user's AES key
+        ciphertext, r = encrypt(user_aes_key, plaintext_bytes)
+        if (is256bit):
+            zero = 0
+            zero_bytes = zero.to_bytes((zero.bit_length() + 7) // 8, 'big')
+            ciphertextHigh, rHigh = encrypt(user_aes_key, zero_bytes)
+            ct = ciphertextHigh + rHigh + ciphertext + r
+        else:
+            ct = ciphertext + r
+    else:
+        padded_plaintext_bytes = bytes(BLOCK_SIZE*2 - len(plaintext_bytes)) + plaintext_bytes
+        # Encrypt the plaintext with the user's AES key
+        ciphertextHigh, rHigh = encrypt(user_aes_key, padded_plaintext_bytes[:BLOCK_SIZE])
+        ciphertextLow, rLow = encrypt(user_aes_key, padded_plaintext_bytes[BLOCK_SIZE:])
+        ct = ciphertextHigh + rHigh + ciphertextLow + rLow
 
     # Sign the message
     signature = signIT(sender_address_bytes, contract_address_bytes, ct, signing_key, eip191)

--- a/python/soda_python_sdk/test.py
+++ b/python/soda_python_sdk/test.py
@@ -2,7 +2,7 @@ import unittest
 import tempfile
 import os
 from Crypto.Random import get_random_bytes
-from crypto import encrypt, decrypt, load_aes_key, write_aes_key, generate_aes_key, signIT, generate_rsa_keypair, encrypt_rsa, decrypt_rsa, get_func_sig, prepare_IT, generate_ECDSA_private_key
+from crypto import encrypt, decrypt, load_aes_key, write_aes_key, generate_aes_key, signIT, generate_rsa_keypair, encrypt_rsa, decrypt_rsa, get_func_sig, prepare_IT, generate_ECDSA_private_key, prepare_IT_256
 from crypto import BLOCK_SIZE, ADDRESS_SIZE, FUNC_SIG_SIZE
 from eth_keys import keys
 from web3 import Account
@@ -246,6 +246,29 @@ class TestMpcHelper(unittest.TestCase):
         self.assertEqual(verified, True)
 
         decrypted = decrypt(userKey, ctBytes[BLOCK_SIZE:], ctBytes[:BLOCK_SIZE])
+        decrypted_integer = int.from_bytes(decrypted, 'big')
+        self.assertEqual(plaintext, decrypted_integer)
+
+    def test_prepareIT_256(self):
+        # Arrange
+        plaintext = 1809251394333065553493296640760748560207343510400633813116524750123642650623
+        userKey = bytes.fromhex("b3c3fe73c1bb91862b166a29fe1d63e9")
+        # Create an account object manually
+        sender = Account()
+        sender.address = "0xd67fe7792f18fbd663e29818334a050240887c28"
+        contract = Account()
+        contract.address = "0x69413851f025306dbe12c48ff2225016fc5bbe1b"
+        signingKey = bytes.fromhex("3840f44be5805af188e9b42dda56eb99eefc88d7a6db751017ff16d0c5f8143e")
+
+        # Act
+        # Call the sign function
+        (ct, _) = prepare_IT_256(plaintext, userKey, sender, contract, signingKey)
+        ctHigh, ctLow = ct
+        # Convert the integer to a byte slice with size aligned to 8.
+        ct1Bytes = ctHigh.to_bytes((ctHigh.bit_length() + 7) // 8, 'big')
+        ct2Bytes = ctLow.to_bytes((ctLow.bit_length() + 7) // 8, 'big')
+
+        decrypted = decrypt(userKey, ct1Bytes[BLOCK_SIZE:2*BLOCK_SIZE], ct1Bytes[:BLOCK_SIZE], ct2Bytes[BLOCK_SIZE:2*BLOCK_SIZE], ct2Bytes[:BLOCK_SIZE])
         decrypted_integer = int.from_bytes(decrypted, 'big')
         self.assertEqual(plaintext, decrypted_integer)
 

--- a/ts/crypto.test.ts
+++ b/ts/crypto.test.ts
@@ -5,7 +5,8 @@ import {
     encrypt, encryptRSA,
     FUNC_SIG_SIZE,
     generateAesKey,
-    generateECDSAPrivateKey, generateRSAKeyPair, getFuncSig, HEX_BASE, prepareIT, prepareMessage, signIT
+    generateECDSAPrivateKey, generateRSAKeyPair, getFuncSig, HEX_BASE, prepareIT, prepareMessage, signIT, prepareIT256, writeBigUInt256BE,
+    CT_SIZE
 } from "./crypto"
 import fs from 'fs';
 import crypto from 'crypto';
@@ -319,6 +320,37 @@ describe('Crypto Tests', () => {
         assert.deepStrictEqual(plaintext, intResult);
     });
 
+    // Test case for verify signature
+    it('should prepare IT 256 bits using fixed data', () => {
+        // Arrange
+        // Simulate the generation of random bytes
+        const plaintext = BigInt("34028236692093846346337460743176821145600");
+        const userKey = Buffer.from('b3c3fe73c1bb91862b166a29fe1d63e9', 'hex');;
+        const sender = new Address(toBuffer(Buffer.from('d67fe7792f18fbd663e29818334a050240887c28', 'hex')));
+        const contract = new Address(toBuffer(Buffer.from('69413851f025306dbe12c48ff2225016fc5bbe1b', 'hex')));
+        const signingKey = Buffer.from('3840f44be5805af188e9b42dda56eb99eefc88d7a6db751017ff16d0c5f8143e', 'hex');
+
+        // Act
+        // Generate the signature
+        const {ciphertext, signature} = prepareIT256(plaintext, userKey, sender.toBuffer(), contract.toBuffer(), signingKey);
+
+        const ctHighBytes = Buffer.alloc(CT_SIZE); // Allocate a buffer of size 32 bytes
+        writeBigUInt256BE(ctHighBytes, ciphertext.ciphertextHigh); // Write the uint256 value to the buffer as big-endian
+        const ctLowBytes = Buffer.alloc(CT_SIZE); // Allocate a buffer of size 32 bytes
+        writeBigUInt256BE(ctLowBytes, ciphertext.ciphertextLow); // Write the uint256 value to the buffer as big-endian
+        // Decrypt the ct and check the decrypted value is equal to the plaintext
+        const decryptedBuffer = decrypt(userKey, ctHighBytes.subarray(BLOCK_SIZE, ctHighBytes.length), ctHighBytes.subarray(0, BLOCK_SIZE), ctLowBytes.subarray(BLOCK_SIZE, ctLowBytes.length), ctLowBytes.subarray(0, BLOCK_SIZE));
+
+        // Convert the plaintext to bytes
+        const hexString = plaintext.toString(16).padStart(64, '0');
+        const plaintextBytes = Buffer.from(hexString, 'hex'); 
+
+        // Assert
+        const expectedBytes = decryptedBuffer.subarray(decryptedBuffer.length - plaintextBytes.length, decryptedBuffer.length)
+        assert.deepStrictEqual(plaintextBytes.toString('hex'), Buffer.from(expectedBytes).toString('hex'));
+        const intResult = uint8ArrayToBigInt(decryptedBuffer);
+        assert.deepStrictEqual(plaintext, intResult);
+    });
 
     // Test case for test rsa encryption scheme
     it('should encrypt and decrypt a message using RSA scheme', () => {

--- a/ts/crypto.ts
+++ b/ts/crypto.ts
@@ -98,7 +98,7 @@ export function decrypt(key: Uint8Array, r: Uint8Array, ciphertext: Uint8Array, 
         const encryptedR2 = aesEcbEncrypt(r2, key);
 
         // XOR the encrypted random value 'r' with the ciphertext to obtain the plaintext
-        const plaintext2 = new Uint8Array(encryptedR2.length);
+        const plaintext2 = new Uint8Array(BLOCK_SIZE);
         for (let i = 0; i < encryptedR2.length; i++) {
             plaintext2[i] = encryptedR2[i] ^ ciphertext2[i];
         }
@@ -302,7 +302,7 @@ export function prepareIT(
   signingKey:Buffer,
   eip191 = false
 ):{ctInt:bigint, signature:Buffer} {
-    // Get the bytes of the sender, contract, and function signature
+    // Get the bytes of the sender, contract
     // todo: check if sender and contract are already in bytes
     const senderBytes = sender;
     const contractBytes = contract;
@@ -342,10 +342,7 @@ export function prepareIT(
  */
 export function prepareIT256(plaintext:bigint, userAesKey:Buffer, sender:Buffer, contract:Buffer, signingKey:Buffer, eip191=false) {
 
-    // Get the bytes of the sender, contract, and function signature
-    const senderBytes = toBuffer(sender)
-    const contractBytes = toBuffer(contract)
-
+    // todo: check if sender and contract are already in bytes (as in regular prepareIT)
     // Convert the plaintext to bytes
     const plaintextBigInt = BigInt(plaintext);
     const bitSize = plaintextBigInt.toString(2).length;
@@ -387,7 +384,7 @@ export function prepareIT256(plaintext:bigint, userAesKey:Buffer, sender:Buffer,
     }
 
     // Sign the message
-    const signature = signIT(senderBytes, contractBytes, ct, signingKey, eip191);
+    const signature = signIT(sender, contract, ct, signingKey, eip191);
 
     const ciphertextHigh = ct.slice(0, CT_SIZE);
     const ciphertextLow = ct.slice(CT_SIZE);

--- a/ts/crypto.ts
+++ b/ts/crypto.ts
@@ -1,5 +1,6 @@
 import forge from 'node-forge'
 import {ethers} from "ethers";
+import { toBuffer } from 'ethereumjs-util';
 
 export const BLOCK_SIZE = 16; // AES block size in bytes
 export const ADDRESS_SIZE = 20; // 160-bit is the output of the Keccak-256 algorithm on the sender/contract address
@@ -7,6 +8,7 @@ export const FUNC_SIG_SIZE = 4;
 export const CT_SIZE = 32;
 export const KEY_SIZE = 32;
 export const HEX_BASE = 16;
+export const MAX_PLAINTEXT_BIT_SIZE = 256;
 
 /**
  * Encrypts a plaintext using AES encryption with a given key.
@@ -44,10 +46,12 @@ export function encrypt(key: Uint8Array, plaintext: Uint8Array):{ ciphertext: Bu
  * @param {Buffer} key - The AES key (16 bytes).
  * @param {Buffer} r - The random value used during encryption (16 bytes).
  * @param {Buffer} ciphertext - The ciphertext to decrypt (16 bytes).
+ * @param {Buffer} r2 - In case of 256 bits plaintext, there is a second random value.
+ * @param {Buffer} ciphertext2 - In case of 256 bits plaintext, there is a second ciphertext.
  * @returns {Uint8Array} - The decrypted plaintext.
  * @throws {RangeError} - Throws if any input size is incorrect.
  */
-export function decrypt(key: Uint8Array, r: Uint8Array, ciphertext: Uint8Array): Uint8Array {
+export function decrypt(key: Uint8Array, r: Uint8Array, ciphertext: Uint8Array, r2: Uint8Array | null = null, ciphertext2: Uint8Array | null = null): Uint8Array {
     // Ensure ciphertext size is 128 bits (16 bytes)
     if (ciphertext.length !== BLOCK_SIZE) {
         throw new RangeError("Ciphertext size must be 128 bits.");
@@ -63,11 +67,43 @@ export function decrypt(key: Uint8Array, r: Uint8Array, ciphertext: Uint8Array):
         throw new RangeError("Random size must be 128 bits.");
     }
 
+    if (r2 !== null) {
+        if (r2.length !== BLOCK_SIZE) {
+            throw new RangeError("Random2 size must be 128 bits, received " + r2.length + " bytes.");
+        }
+        if (ciphertext2 === null) {
+            throw new RangeError("Ciphertext2 is required.");
+        }
+    }
+
+    if (ciphertext2 !== null) {
+        if (ciphertext2.length !== BLOCK_SIZE) {
+            throw new RangeError("Ciphertext2 size must be 128 bits, received " + ciphertext2.length + " bytes.");
+        }
+
+        if (r2 === null) {
+            throw new RangeError("Random2 is required.");
+        }
+    }
+
     const encryptedR = aesEcbEncrypt(r, key);
-    const plaintext = new Uint8Array(BLOCK_SIZE);
+    let plaintext = new Uint8Array(BLOCK_SIZE);
 
     for (let i = 0; i < encryptedR.length; i++) {
         plaintext[i] = encryptedR[i] ^ ciphertext[i];
+    }
+
+    if (r2 !== null && ciphertext2 !== null) {
+        // Encrypt the random value 'r2' using AES in ECB mode
+        const encryptedR2 = aesEcbEncrypt(r2, key);
+
+        // XOR the encrypted random value 'r' with the ciphertext to obtain the plaintext
+        const plaintext2 = new Uint8Array(encryptedR2.length);
+        for (let i = 0; i < encryptedR2.length; i++) {
+            plaintext2[i] = encryptedR2[i] ^ ciphertext2[i];
+        }
+
+        plaintext = new Uint8Array([...plaintext, ...plaintext2]);
     }
 
     return plaintext;
@@ -100,7 +136,7 @@ export function generateECDSAPrivateKey(): Buffer {
  * Supports optional EIP-191 signing.
  * @param {Buffer} sender - The sender's address (20 bytes).
  * @param {Buffer} addr - The contract address (20 bytes).
- * @param {Buffer} ct - The ciphertext (32 bytes).
+ * @param {Buffer} ct - The ciphertext (32 bytes in case of 128 bits plaintext or less, or 64 bytes in case of 256 bits plaintext).
  * @param {Buffer} key - The signing key (32 bytes).
  * @param {boolean} eip191 - Whether to use EIP-191 signing (default: false).
  * @returns {Buffer} - The signature as a Buffer.
@@ -113,8 +149,8 @@ export function signIT(sender:Buffer, addr:Buffer, ct:Buffer, key:Buffer, eip191
     if (addr.length !== ADDRESS_SIZE) {
         throw new RangeError(`Invalid contract address length: ${addr.length} bytes, must be ${ADDRESS_SIZE} bytes`);
     }
-    if (ct.length !== CT_SIZE) {
-        throw new RangeError(`Invalid ct length: ${ct.length} bytes, must be ${CT_SIZE} bytes`);
+    if (ct.length !== CT_SIZE && ct.length !== 2*CT_SIZE) {
+        throw new RangeError(`Invalid ct length: ${ct.length} bytes, must be ${CT_SIZE} bytes in case of 128 bits plaintext or less, or ${2*CT_SIZE} bytes in case of 256 bits plaintext or less`);
     }
     if (key.length !== KEY_SIZE) {
         throw new RangeError(`Invalid key length: ${key.length} bytes, must be ${KEY_SIZE} bytes`);
@@ -221,6 +257,33 @@ export function prepareMessage(
 }
 
 /**
+ * Writes a uint128 value to a buffer as big-endian.
+ * @param {Buffer} buffer - The buffer to write the value to.
+ * @param {bigint} value - The value to write to the buffer.
+ * @param {number} offset - The offset to write the value to.
+ */
+function writeBigUInt128BE(buffer: Buffer, value: bigint, offset = 0) {
+    const hexString = value.toString(HEX_BASE).padStart(CT_SIZE, '0');
+    const bytes = Buffer.from(hexString, 'hex');
+    bytes.copy(buffer, offset);
+}
+
+/**
+ * Writes a uint256 value to a buffer as big-endian.
+ * @param {Buffer} buffer - The buffer to write the value to.
+ * @param {bigint} value - The value to write to the buffer.
+ * @param {number} offset - The offset to write the value to.
+ */
+export function writeBigUInt256BE(buffer: Buffer, value: bigint, offset = 0) {
+    const hexString = value.toString(HEX_BASE).padStart(CT_SIZE*2, '0');
+    const bytes = Buffer.from(hexString, 'hex');
+    if (buffer.length > bytes.length) {
+        offset = buffer.length - bytes.length;
+    }
+    bytes.copy(buffer, offset);
+}
+
+/**
  * Prepares an IT by encrypting the plaintext, signing the encrypted message,
  * and packaging the resulting data. This data represents encrypted data that can be sent to the contract.
  * @param {bigint} plaintext - The plaintext value to be encrypted as a BigInt.
@@ -245,8 +308,14 @@ export function prepareIT(
     const contractBytes = contract;
 
     // Convert the plaintext to bytes
-    const plaintextBytes = Buffer.alloc(8); // Allocate a buffer of size 8 bytes
-    plaintextBytes.writeBigUInt64BE(BigInt(plaintext)); // Write the uint64 value to the buffer as little-endian
+    const plaintextBigInt = BigInt(plaintext);
+    const bitSize = plaintextBigInt.toString(2).length;
+    if (bitSize > MAX_PLAINTEXT_BIT_SIZE/2) {
+        throw new RangeError("Plaintext size must be 128 bits or smaller. To prepare a 256 bit plaintext, use prepareIT256 instead.");
+    }
+
+    const plaintextBytes = Buffer.alloc(BLOCK_SIZE); // Allocate a buffer of size 16 bytes
+    writeBigUInt128BE(plaintextBytes, plaintextBigInt); // Write the uint128 value to the buffer as big-endiandian
 
     // Encrypt the plaintext using AES key
     const { ciphertext, r } = encrypt(userAesKey, plaintextBytes);
@@ -259,6 +328,75 @@ export function prepareIT(
     const ctInt = BigInt('0x' + ct.toString('hex'));
 
     return { ctInt, signature };
+}
+
+/**
+ * Prepares a 256 bit IT by encrypting both parts of the plaintext, signing the encrypted message,
+ * and packaging the resulting data. This data represents encrypted data that can be sent to the contract.
+ * @param {bigint} plaintext - The plaintext value to be encrypted as a BigInt.
+ * @param {Buffer} userAesKey - The AES key used for encryption (16 bytes).
+ * @param {Buffer} sender - The sender's address as a Buffer.
+ * @param {Buffer} contract - The contract's address as a Buffer.
+ * @param {Buffer} signingKey - The ECDSA signing key (32 bytes).
+ * @param {boolean} [eip191=false] - Whether to use EIP-191 signing (default: false).
+ */
+export function prepareIT256(plaintext:bigint, userAesKey:Buffer, sender:Buffer, contract:Buffer, signingKey:Buffer, eip191=false) {
+
+    // Get the bytes of the sender, contract, and function signature
+    const senderBytes = toBuffer(sender)
+    const contractBytes = toBuffer(contract)
+
+    // Convert the plaintext to bytes
+    const plaintextBigInt = BigInt(plaintext);
+    const bitSize = plaintextBigInt.toString(2).length;
+    if (bitSize > MAX_PLAINTEXT_BIT_SIZE) {
+        throw new RangeError("Plaintext size must be between 128 and 256 bits.");
+    }
+
+    let ct = Buffer.alloc(0);
+
+    // In case of 128 bits plaintext, encrypt it as the low part of the ct, and then encrypt the high part of the ct with zeros
+    if (bitSize <= MAX_PLAINTEXT_BIT_SIZE/2) {
+        const plaintextBytes = Buffer.alloc(BLOCK_SIZE); // Allocate a buffer of size 16 bytes
+        writeBigUInt128BE(plaintextBytes, plaintextBigInt); // Write the uint128 value to the buffer as big-endian
+        // Encrypt the plaintext using AES key
+        const {ciphertext, r} = encrypt(userAesKey, plaintextBytes);
+
+        // Encrypt the high part of the ct with zeros
+        const zero = BigInt(0);
+        const zeroBytes = Buffer.alloc(BLOCK_SIZE);
+        writeBigUInt128BE(zeroBytes, zero);
+        const {ciphertext: ciphertextHigh, r: rHigh} = encrypt(userAesKey, zeroBytes);
+        ct = Buffer.concat([ciphertextHigh, rHigh, ciphertext, r]);
+
+    } else if (bitSize <= MAX_PLAINTEXT_BIT_SIZE) {
+        const plaintextBytes = Buffer.alloc(CT_SIZE); // Allocate a buffer of size 32 bytes
+        writeBigUInt256BE(plaintextBytes, plaintextBigInt); // Write the uint256 value to the buffer as big-endian
+
+        // Encrypt each part of the plaintext using AES key
+        const resultHigh = encrypt(userAesKey, plaintextBytes.slice(0, BLOCK_SIZE));
+        const resultLow = encrypt(userAesKey, plaintextBytes.slice(BLOCK_SIZE));
+
+        // Now destructure
+        const { ciphertext: ciphertextHigh, r: rHigh } = resultHigh;
+        const { ciphertext: ciphertextLow, r: rLow } = resultLow;
+
+        ct = Buffer.concat([ciphertextHigh, rHigh, ciphertextLow, rLow]);
+    } else if (bitSize > MAX_PLAINTEXT_BIT_SIZE) {
+        throw new RangeError("Plaintext size must be 256 bits or smaller.");
+    }
+
+    // Sign the message
+    const signature = signIT(senderBytes, contractBytes, ct, signingKey, eip191);
+
+    const ciphertextHigh = ct.slice(0, CT_SIZE);
+    const ciphertextLow = ct.slice(CT_SIZE);
+
+    // Convert Buffer to uint256 (BigInt) for Solidity compatibility
+    const ciphertextHighUint = BigInt('0x' + ciphertextHigh.toString('hex'));
+    const ciphertextLowUint = BigInt('0x' + ciphertextLow.toString('hex'));
+
+    return { ciphertext: {ciphertextHigh: ciphertextHighUint, ciphertextLow: ciphertextLowUint}, signature };
 }
 
 /**


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add support for 256-bit plaintext encryption/decryption

- Introduce new `prepareIT256` functions across all languages

- Enhance error handling with detailed validation messages

- Update tests to verify 256-bit functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["128-bit encryption"] --> B["Enhanced decrypt function"]
  B --> C["256-bit support"]
  C --> D["prepareIT256 functions"]
  D --> E["Cross-language tests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>crypto.test.ts</strong><dd><code>Add 256-bit encryption test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ts/crypto.test.ts

<ul><li>Add test for <code>prepareIT256</code> function with 256-bit plaintext<br> <li> Import new functions <code>prepareIT256</code>, <code>writeBigUInt256BE</code>, <code>CT_SIZE</code><br> <li> Verify encryption/decryption roundtrip for 256-bit values</ul>


</details>


  </td>
  <td><a href="https://github.com/soda-mpc/soda-sdk/pull/39/files#diff-8e33690aef67ed008c9bdf804f3782702f7a2a92ecabd13755a7a77244acf879">+33/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test.py</strong><dd><code>Add 256-bit encryption test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/soda_python_sdk/test.py

<ul><li>Import <code>prepare_IT_256</code> function<br> <li> Add test case for 256-bit plaintext encryption/decryption<br> <li> Verify roundtrip functionality with large integer values</ul>


</details>


  </td>
  <td><a href="https://github.com/soda-mpc/soda-sdk/pull/39/files#diff-71867494de3182fae9a316c914e2bb12f2eb5a037ad9f1a7b000751782b1b61b">+24/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test.mjs</strong><dd><code>Add 256-bit encryption test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

js/test.mjs

<ul><li>Import <code>prepareIT256</code> and <code>writeBigUInt256BE</code> functions<br> <li> Add test case for 256-bit plaintext encryption<br> <li> Import <code>CT_SIZE</code> constant for buffer allocation<br> <li> Verify encryption/decryption roundtrip for large values</ul>


</details>


  </td>
  <td><a href="https://github.com/soda-mpc/soda-sdk/pull/39/files#diff-65f4db482cfc04391a5146699b143f8f0dc62637652cf3431a0a125e652321f5">+33/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>crypto.ts</strong><dd><code>Implement 256-bit encryption support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ts/crypto.ts

<ul><li>Enhance <code>decrypt</code> function to support dual ciphertext/random pairs<br> <li> Add <code>prepareIT256</code> function for 256-bit plaintext handling<br> <li> Add <code>writeBigUInt256BE</code> and <code>writeBigUInt128BE</code> utility functions<br> <li> Update <code>signIT</code> to accept both 32 and 64 byte ciphertext lengths<br> <li> Add <code>MAX_PLAINTEXT_BIT_SIZE</code> constant and size validation</ul>


</details>


  </td>
  <td><a href="https://github.com/soda-mpc/soda-sdk/pull/39/files#diff-fc3c45155a2e61706831ce64759aab023930950492521f9dac12604112cc1de2">+145/-7</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>crypto.py</strong><dd><code>Add 256-bit encryption support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/soda_python_sdk/crypto.py

<ul><li>Add <code>prepare_IT_256</code> function for 256-bit plaintext support<br> <li> Enhance <code>decrypt</code> function with optional second ciphertext/random <br>parameters<br> <li> Update <code>signIT</code> validation to accept 32 or 64 byte ciphertext<br> <li> Add <code>MAX_PLAINTEXT_BIT_SIZE</code> constant and size validation</ul>


</details>


  </td>
  <td><a href="https://github.com/soda-mpc/soda-sdk/pull/39/files#diff-d53c4feba2206a5833b5da6818e6e6fff35def5264eed2c2ec9e35234c2244b5">+70/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>crypto.mjs</strong><dd><code>Implement 256-bit encryption support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

js/crypto.mjs

<ul><li>Add <code>prepareIT256</code> function for 256-bit plaintext handling<br> <li> Enhance <code>decrypt</code> function to support dual ciphertext pairs<br> <li> Add <code>writeBigUInt256BE</code> and <code>writeBigUInt128BE</code> utility functions<br> <li> Update <code>signIT</code> validation for variable ciphertext lengths<br> <li> Add <code>maxPlaintextBitSize</code> constant and improved error messages</ul>


</details>


  </td>
  <td><a href="https://github.com/soda-mpc/soda-sdk/pull/39/files#diff-5fcc4a2a330e28c5702faca650ad51058ba254e603035506e57a44043bf59782">+121/-9</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>crypto_test.go</strong><dd><code>Fix test parameter ordering and error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

golang_cli/crypto/crypto_test.go

<ul><li>Fix parameter order in <code>checkIT</code> function calls<br> <li> Add proper error handling for file operations<br> <li> Improve error checking for random generation<br> <li> Fix file reading validation logic</ul>


</details>


  </td>
  <td><a href="https://github.com/soda-mpc/soda-sdk/pull/39/files#diff-dd414c60c1ebd07f3f75bf0772b043c0474efc93b19455632aca10bcc5fd458f">+12/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

