### PR TITLE
Introduce `verifyEncryptToUserSignature` in JS and Python to verify multiple signatures

### DIFF
--- a/js/crypto.mjs
+++ b/js/crypto.mjs
@@ -439,7 +439,7 @@ export function verifyEncryptToUserSignature(publicKey, handles, outputs, signat
         throw new RangeError("handles and outputs must have the same length");
     }
     
-    if (handles.length === 0 || outputs.length === 0){
+    if (handles.length === 0){
         throw new RangeError("handles and outputs must be non-empty");
     }
 

--- a/js/crypto.mjs
+++ b/js/crypto.mjs
@@ -445,12 +445,6 @@ export function verifyEncryptToUserSignature(publicKey, handles, outputs, signat
 
     let allHandles = Buffer.concat(handles);
     let allOutputs = Buffer.concat(outputs);
-    // for (let i = 0; i < handles.length; i++){
-    //     allHandles += Buffer.from(handles[i]);
-    // }
-    // for (let i = 0; i < outputs.length; i++){
-    //     allOutputs += Buffer.from(outputs[i]);
-    // }
 
     const message = Buffer.concat([allHandles, allOutputs]);
 

--- a/js/crypto.mjs
+++ b/js/crypto.mjs
@@ -427,27 +427,52 @@ export function readPublicKeyFromPem(pemPublicKeyPath) {
 }
 
 /**
+ * 
+ * @param {Buffer|Uint8Array} publicKey - The public key in X||Y format (64 bytes).
+ * @param {Buffer|Uint8Array} handles - The handles to be verified.
+ * @param {Buffer|Uint8Array} outputs - The output bytes to be verified.
+ * @param {Buffer|Uint8Array} signature - The signature in r||s||v format (65 bytes).
+ * @returns {boolean} - Returns true if the signature is valid, false otherwise.
+ */
+export function verifyEncryptToUserSignature(publicKey, handles, outputs, signature){    
+    if (handles.length !== outputs.length){
+        throw new RangeError("handles and outputs must have the same length");
+    }
+    
+    if (handles.length === 0 || outputs.length === 0){
+        throw new RangeError("handles and outputs must be non-empty");
+    }
+
+    let allHandles = Buffer.concat(handles);
+    let allOutputs = Buffer.concat(outputs);
+    // for (let i = 0; i < handles.length; i++){
+    //     allHandles += Buffer.from(handles[i]);
+    // }
+    // for (let i = 0; i < outputs.length; i++){
+    //     allOutputs += Buffer.from(outputs[i]);
+    // }
+
+    const message = Buffer.concat([allHandles, allOutputs]);
+
+    return verifySignature(publicKey, message, signature);
+}
+
+/**
  * Verify the signature of the message.
  * @param {Buffer|Uint8Array} publicKey - The public key in X||Y format (64 bytes).
- * @param {Buffer|Uint8Array} handleBytes - The handle bytes to be verified.
- * @param {Buffer|Uint8Array} output - The output bytes to be verified.
+ * @param {Buffer|Uint8Array} message - The message to be verified.
  * @param {Buffer|Uint8Array} signature - The signature in r||s||v format (65 bytes).
  * @returns {boolean} - Returns true if the signature is valid, false otherwise.
  * @throws {TypeError} - Throws if any of the input parameters are of invalid types.
  * @throws {RangeError} - Throws if any of the input parameters are empty or have incorrect lengths.
  */
-export function verifySignature(publicKey, handleBytes, output, signature) {
+export function verifySignature(publicKey, message, signature) {
     // Validate input types
-    if (!(handleBytes instanceof Buffer) && !(handleBytes instanceof Uint8Array)) {
-        throw new TypeError("handle_bytes must be Buffer or Uint8Array");
+    if (!(message instanceof Buffer) && !(message instanceof Uint8Array)) {
+        throw new TypeError("message must be Buffer or Uint8Array");
     }
-    if (!(output instanceof Buffer) && !(output instanceof Uint8Array)) {
-        throw new TypeError("output must be Buffer or Uint8Array");
-    }
-    
-    // Validate non-empty
-    if (handleBytes.length === 0 || output.length === 0) {
-        throw new RangeError("handle_bytes and output must be non-empty");
+    if (message.length === 0) {
+        throw new RangeError("message must be non-empty");
     }
 
     // Validate signature length
@@ -466,11 +491,6 @@ export function verifySignature(publicKey, handleBytes, output, signature) {
         throw new RangeError(`Invalid public key length: ${publicKey.length} bytes, must be 64 (X||Y)`);
     }
 
-    // Create the message to be signed
-    const handleBuf = Buffer.from(handleBytes);
-    const outputBuf = Buffer.from(output);
-    const message = Buffer.concat([handleBuf, outputBuf]);
-    
     // Hash the message
     const messageHash = ethereumjsUtil.keccak256(message);
 

--- a/js/test.mjs
+++ b/js/test.mjs
@@ -143,8 +143,8 @@ describe('Crypto Tests', () => {
         const signatureBytes = signIT(sender, addr, ct, key);
 
         const publicKey = ethereumjsUtil.privateToPublic(key);
-        const message = Buffer.concat([sender, addr]);
-        const verified = verifySignature(publicKey, message, ct, signatureBytes);
+        const message = Buffer.concat([sender, addr, ct]);
+        const verified = verifySignature(publicKey, message, signatureBytes);
 
         // Assert
         assert.strictEqual(verified, true);

--- a/python/soda_python_sdk/crypto.py
+++ b/python/soda_python_sdk/crypto.py
@@ -262,17 +262,38 @@ def read_public_key_from_pem(pem_public_key_path):
 
     return uncompressed65[1:]  # 64 bytes: X||Y
 
-def verify_signature(public_key, handle_bytes, output, signature):
+def verify_encrypt_to_user_signature(public_key, handles, output, signature):
     """Verify the signature of the message."""
 
-    if not isinstance(handle_bytes, (bytes, bytearray)) or not isinstance(output, (bytes, bytearray)):  
-        raise TypeError("handle_bytes and output must be bytes")  
-    if len(handle_bytes) == 0 or len(output) == 0:  
-        raise ValueError("handle_bytes and output must be non-empty")  
+    if (len(handles) != len(output)):
+        raise ValueError("handles and output must have the same length")
+
+    if len(handles) == 0 or len(output) == 0:  
+        raise ValueError("handles and output must be non-empty") 
+
+    all_handles = bytes()
+    for handle in handles:
+        all_handles += handle
+
+    all_outputs = bytes()
+    for output in output:
+        all_outputs += output
 
     # Create the message to be signed
-    message = handle_bytes + output
+    message = all_handles + all_outputs
     
+    return verify_signature(public_key, message, signature)
+
+def verify_signature(public_key, message, signature):
+    """Verify the signature of the message."""
+
+    if not isinstance(message, (bytes, bytearray)):  
+        raise TypeError("message must be of type bytes or bytearray")  
+    if len(message) == 0:  
+        raise ValueError("message must be non-empty")  
+
+    if not isinstance(signature, (bytes, bytearray)):  
+        raise TypeError("signature must be of type bytes or bytearray")  
     if len(signature) != SIGNATURE_SIZE:
         raise ValueError(f"Invalid signature length: {len(signature)} bytes, must be {SIGNATURE_SIZE} bytes")
 
@@ -281,7 +302,7 @@ def verify_signature(public_key, handle_bytes, output, signature):
 
     # Validate public key format: expect 64-byte X||Y  
     if not isinstance(public_key, (bytes, bytearray)):  
-        raise TypeError("public_key must be bytes")  
+        raise TypeError("public_key must be of type bytes or bytearray")  
     if len(public_key) != EC_PUBLIC_KEY_SIZE - 1:  
         raise ValueError(f"Invalid public key length: {len(public_key)} bytes, must be 64 (X||Y)")  
 

--- a/python/soda_python_sdk/crypto.py
+++ b/python/soda_python_sdk/crypto.py
@@ -262,21 +262,21 @@ def read_public_key_from_pem(pem_public_key_path):
 
     return uncompressed65[1:]  # 64 bytes: X||Y
 
-def verify_encrypt_to_user_signature(public_key, handles, output, signature):
+def verify_encrypt_to_user_signature(public_key, handles, outputs, signature):
     """Verify the signature of the message."""
 
-    if (len(handles) != len(output)):
-        raise ValueError("handles and output must have the same length")
+    if (len(handles) != len(outputs)):
+        raise ValueError("handles and outputs must have the same length")
 
-    if len(handles) == 0 or len(output) == 0:  
-        raise ValueError("handles and output must be non-empty") 
+    if len(handles) == 0:  
+        raise ValueError("handles and outputs must be non-empty") 
 
     all_handles = bytes()
     for handle in handles:
         all_handles += handle
 
     all_outputs = bytes()
-    for output in output:
+    for output in outputs:
         all_outputs += output
 
     # Create the message to be signed

--- a/python/soda_python_sdk/test.py
+++ b/python/soda_python_sdk/test.py
@@ -145,7 +145,7 @@ class TestMpcHelper(unittest.TestCase):
         signature_bytes = signIT(sender, addr, ct, key)
 
         public_key = keys.PrivateKey(key).public_key.to_bytes()
-        verified = verify_signature(public_key, sender + addr, ct, signature_bytes)
+        verified = verify_signature(public_key, sender + addr + ct, signature_bytes)
        
         # Assert
         self.assertEqual(verified, True)


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Introduce `verifyEncryptToUserSignature` function to handle multiple signatures

- Refactor `verifySignature` to accept pre-constructed message parameter

- Unify message construction logic across JS and Python implementations

- Improve input validation with consistent error handling and type checking


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Multiple handles and outputs"] --> B["verifyEncryptToUserSignature"]
  B --> C["Concatenate handles and outputs"]
  C --> D["verifySignature"]
  D --> E["Verify signature against message"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>crypto.py</strong><dd><code>Add multi-signature verification and refactor message handling</code></dd></summary>
<hr>

python/soda_python_sdk/crypto.py

<ul><li>Introduced <code>verify_encrypt_to_user_signature</code> function to handle arrays <br>of handles and outputs<br> <li> Refactored <code>verify_signature</code> to accept a pre-constructed message <br>instead of separate handle_bytes and output parameters<br> <li> Enhanced input validation to check array length consistency and <br>non-empty constraints<br> <li> Improved error messages for better clarity on type and value <br>requirements</ul>


</details>


  </td>
  <td><a href="https://github.com/soda-mpc/soda-sdk/pull/48/files#diff-d53c4feba2206a5833b5da6818e6e6fff35def5264eed2c2ec9e35234c2244b5">+28/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>crypto.mjs</strong><dd><code>Add multi-signature verification and refactor message handling</code></dd></summary>
<hr>

js/crypto.mjs

<ul><li>Introduced <code>verifyEncryptToUserSignature</code> function to verify multiple <br>handles and outputs signatures<br> <li> Refactored <code>verifySignature</code> to accept a pre-constructed message <br>parameter instead of separate handleBytes and output<br> <li> Simplified input validation by consolidating checks into the message <br>parameter<br> <li> Updated JSDoc comments to reflect new parameter names and function <br>signatures</ul>


</details>


  </td>
  <td><a href="https://github.com/soda-mpc/soda-sdk/pull/48/files#diff-5fcc4a2a330e28c5702faca650ad51058ba254e603035506e57a44043bf59782">+37/-17</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

