### PR TITLE
Refactor signature verification functions to use ecrecover

### DIFF
--- a/js/crypto.mjs
+++ b/js/crypto.mjs
@@ -373,7 +373,7 @@ export function verifySignatures(message, signatures, signers){
             console.log("Recovered address " + recoveredAddress + " not in the list of signers")
             return false;
         }
-        if (recoveredAddress in recoveredAddresses) {
+        if (recoveredAddresses.includes(recoveredAddress)) {
             console.log("Same address recovered multiple times")
             return false;
         }

--- a/js/crypto.mjs
+++ b/js/crypto.mjs
@@ -358,109 +358,37 @@ export function prepareIT256(plaintext, userAesKey, sender, contract, signingKey
     return { ciphertext: {ciphertextHigh: ciphertextHighUint, ciphertextLow: ciphertextLowUint}, signature };
 }
 
-export function readPublicKeyFromPem(pemPublicKeyPath) {
-    // Read the PEM file
-    const pemPublicKey = fs.readFileSync(pemPublicKeyPath, 'utf8');
-
-    // Use Node.js crypto to create a KeyObject from PEM
-    // This handles PEM parsing automatically
-    const keyObject = crypto.createPublicKey(pemPublicKey);
-    
-    // Get the key type and parameters
-    const keyType = keyObject.asymmetricKeyType;
-    if (keyType !== 'ec') {
-        throw new Error(`Invalid key type: expected 'ec', got '${keyType}'`);
-    }
-    
-    // Export the public key in DER format
-    const derBytes = keyObject.export({ format: 'der', type: 'spki' });
-    
-    // Parse ASN.1 DER structure to extract the EC point
-    // SubjectPublicKeyInfo: SEQUENCE { AlgorithmIdentifier, BIT STRING { point } }
-    const asn1 = forge.asn1.fromDer(derBytes.toString('binary'));
-    
-    // Check if we have a SEQUENCE
-    if (!asn1) {
-        throw new Error('Invalid PEM format: failed to parse DER');
-    }
-    
-    // Check type - forge uses both 'tag' and 'type' properties
-    const isSequence = (asn1.type === forge.asn1.Type.SEQUENCE) || 
-                       (asn1.tag === forge.asn1.Type.SEQUENCE);
-    if (!isSequence) {
-        throw new Error(`Invalid PEM format: expected SEQUENCE, got type=${asn1.type}, tag=${asn1.tag}`);
-    }
-    
-    // The value should be an array of ASN.1 structures
-    const children = asn1.value;
-    if (!children || !Array.isArray(children) || children.length < 2) {
-        throw new Error('Invalid PEM format: missing public key data');
-    }
-    
-    // Second child is the BIT STRING containing the EC point
-    const bitString = children[1];
-    const isBitString = (bitString.type === forge.asn1.Type.BIT_STRING) ||
-                        (bitString.tag === forge.asn1.Type.BIT_STRING);
-    if (!bitString || !isBitString) {
-        throw new Error(`Invalid PEM format: expected BIT STRING, got type=${bitString?.type}, tag=${bitString?.tag}`);
-    }
-    
-    // BIT STRING: first byte is unused bits count, rest is the actual data
-    // The value is a string in binary format
-    const bitStringData = bitString.value;
-    if (typeof bitStringData !== 'string') {
-        throw new Error('Invalid BIT STRING format: expected string value');
-    }
-    
-    const bitStringBytes = Buffer.from(bitStringData, 'binary');
-    
-    // Skip unused bits indicator (first byte, usually 0)
-    const publicKeyPoint = bitStringBytes.subarray(1);
-    
-    // For secp256k1, uncompressed format is 0x04 || X(32 bytes) || Y(32 bytes) = 65 bytes
-    if (publicKeyPoint.length !== EC_PUBLIC_KEY_SIZE || publicKeyPoint[0] !== 0x04) {
-        throw new Error(`Invalid EC public key format: expected ${EC_PUBLIC_KEY_SIZE} bytes with 0x04 prefix, got ${publicKeyPoint.length} bytes`);
-    }
-    
-    // Return X||Y (skip the 0x04 prefix) - 64 bytes total
-    return publicKeyPoint.subarray(1);
-}
-
 /**
- * 
- * @param {Buffer|Uint8Array} publicKey - The public key in X||Y format (64 bytes).
- * @param {Buffer|Uint8Array} handles - The handles to be verified.
- * @param {Buffer|Uint8Array} outputs - The output bytes to be verified.
- * @param {Buffer|Uint8Array} signature - The signature in r||s||v format (65 bytes).
- * @returns {boolean} - Returns true if the signature is valid, false otherwise.
- */
-export function verifyEncryptToUserSignature(publicKey, handles, outputs, signature){    
-    if (handles.length !== outputs.length){
-        throw new RangeError("handles and outputs must have the same length");
-    }
-    
-    if (handles.length === 0){
-        throw new RangeError("handles and outputs must be non-empty");
-    }
-
-    let allHandles = Buffer.concat(handles);
-    let allOutputs = Buffer.concat(outputs);
-
-    const message = Buffer.concat([allHandles, allOutputs]);
-
-    return verifySignature(publicKey, message, signature);
-}
-
-/**
- * Verify the signature of the message.
- * @param {Buffer|Uint8Array} publicKey - The public key in X||Y format (64 bytes).
+ * Verifies the signatures of the message.
  * @param {Buffer|Uint8Array} message - The message to be verified.
- * @param {Buffer|Uint8Array} signature - The signature in r||s||v format (65 bytes).
- * @returns {boolean} - Returns true if the signature is valid, false otherwise.
- * @throws {TypeError} - Throws if any of the input parameters are of invalid types.
- * @throws {RangeError} - Throws if any of the input parameters are empty or have incorrect lengths.
+ * @param {Buffer|Uint8Array} signatures - The signatures to be verified.
+ * @param {string[]} signers - The list of signers.
+ * @returns {boolean} - Returns true if the signatures are valid, false otherwise.
  */
-export function verifySignature(publicKey, message, signature) {
+export function verifySignatures(message, signatures, signers){  
+    const recoveredAddresses = [];
+    for (const signature of signatures) {
+        const recoveredAddress = recoverAddressFromSignature(message, signature);
+        if (!signers.includes(recoveredAddress)) {
+            console.log("Recovered address " + recoveredAddress + " not in the list of signers")
+            return false;
+        }
+        if (recoveredAddress in recoveredAddresses) {
+            console.log("Same address recovered multiple times")
+            return false;
+        }
+        recoveredAddresses.push(recoveredAddress);
+    }
+    return true;
+}
+
+/**
+ * Recovers the address from the signature.
+ * @param {Buffer|Uint8Array} message - The message to be signed.
+ * @param {Buffer|Uint8Array} signature - The signature in r||s||v format (65 bytes).
+ * @returns {string} - The address recovered from the signature.
+ */
+export function recoverAddressFromSignature(message, signature) {
     // Validate input types
     if (!(message instanceof Buffer) && !(message instanceof Uint8Array)) {
         throw new TypeError("message must be Buffer or Uint8Array");
@@ -477,20 +405,9 @@ export function verifySignature(publicKey, message, signature) {
         throw new RangeError(`Invalid signature length: ${signature.length} bytes, must be ${SIGNATURE_SIZE} bytes`);
     }
 
-    // Validate public key format: expect 64-byte X||Y
-    if (!(publicKey instanceof Buffer) && !(publicKey instanceof Uint8Array)) {
-        throw new TypeError("public_key must be Buffer or Uint8Array");
-    }
-    if (publicKey.length !== EC_PUBLIC_KEY_SIZE - 1) {
-        throw new RangeError(`Invalid public key length: ${publicKey.length} bytes, must be 64 (X||Y)`);
-    }
-
     // Hash the message
     const messageHash = ethereumjsUtil.keccak256(message);
 
-    // Convert public key to Buffer if needed
-    const publicKeyBuf = Buffer.from(publicKey);
-    
     // Convert signature components (r, s, v)
     const { rBytes, sBytes, vByte } = extractSignatureComponents(Buffer.from(signature));
 
@@ -501,9 +418,10 @@ export function verifySignature(publicKey, message, signature) {
 
     // Recover the public key from the signature
     const recoveredPublicKey = ethereumjsUtil.ecrecover(messageHash, v, rBytes, sBytes);
-    
-    // Compare the recovered public key with the provided public key
-    return recoveredPublicKey.equals(publicKeyBuf);
+
+    // Get the address from the recovered public key
+    const addressBuffer = ethereumjsUtil.pubToAddress(recoveredPublicKey);
+    return ethereumjsUtil.toChecksumAddress('0x' + addressBuffer.toString('hex'));
 }
 
 /**

--- a/js/test.mjs
+++ b/js/test.mjs
@@ -6,7 +6,7 @@ import {
     generateECDSAPrivateKey, generateRSAKeyPair,
     getFuncSig,
     prepareIT, prepareIT256, prepareMessage,
-    signIT, verifySignature,
+    signIT, verifySignatures,
     writeBigUInt256BE, extractSignatureComponents
 } from './crypto.mjs';
 
@@ -143,8 +143,9 @@ describe('Crypto Tests', () => {
         const signatureBytes = signIT(sender, addr, ct, key);
 
         const publicKey = ethereumjsUtil.privateToPublic(key);
+        const signerAddress = ethereumjsUtil.toChecksumAddress('0x' + ethereumjsUtil.pubToAddress(publicKey).toString('hex'));
         const message = Buffer.concat([sender, addr, ct]);
-        const verified = verifySignature(publicKey, message, signatureBytes);
+        const verified = verifySignatures(message, [signatureBytes], [signerAddress]);
 
         // Assert
         assert.strictEqual(verified, true);

--- a/python/soda_python_sdk/crypto.py
+++ b/python/soda_python_sdk/crypto.py
@@ -11,6 +11,7 @@ from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.asymmetric import ec
 from eth_account import Account
 from eth_account.messages import encode_defunct
+from web3 import Web3
 
 BLOCK_SIZE = AES.block_size
 ADDRESS_SIZE = 20
@@ -237,55 +238,30 @@ def inner_prepare_IT(plaintext, user_aes_key, sender, contract, signing_key, eip
 
     return ctInt, signature
 
-def read_public_key_from_pem(pem_public_key_path):
-    """Return 64-byte uncompressed EC public key (X||Y) from a PEM public key."""
-    with open(pem_public_key_path, "rb") as f:
-        data = f.read()
+def verify_signatures(message, signatures, signers):
+    """Verify the signatures of the message."""
+    # Normalize signers to checksum addresses for comparison
+    signers_normalized = [Web3.to_checksum_address(signer) for signer in signers]
 
-    pubkey = serialization.load_pem_public_key(data)
-
-    # Ensure it's an EC key (e.g., secp256k1)
-    if not isinstance(pubkey, ec.EllipticCurvePublicKey):
-        raise ValueError("PEM does not contain an EC public key")
-    curve = getattr(pubkey, "curve", None)  
-    if curve is None or getattr(curve, "name", "").lower() != "secp256k1":  
-        raise ValueError(f"Unsupported EC curve: {getattr(curve, 'name', None)}; expected secp256k1") 
-
-    # Get uncompressed point (65 bytes: 0x04 + X(32) + Y(32) for secp256k1)
-    uncompressed65 = pubkey.public_bytes(
-        encoding=serialization.Encoding.X962,
-        format=serialization.PublicFormat.UncompressedPoint,
-    )
-
-    if len(uncompressed65) != EC_PUBLIC_KEY_SIZE or uncompressed65[0] != 0x04:
-        raise ValueError(f"Unexpected uncompressed key format/length: {len(uncompressed65)}")
-
-    return uncompressed65[1:]  # 64 bytes: X||Y
-
-def verify_encrypt_to_user_signature(public_key, handles, outputs, signature):
-    """Verify the signature of the message."""
-
-    if (len(handles) != len(outputs)):
-        raise ValueError("handles and outputs must have the same length")
-
-    if len(handles) == 0:  
-        raise ValueError("handles and outputs must be non-empty") 
-
-    all_handles = bytes()
-    for handle in handles:
-        all_handles += handle
-
-    all_outputs = bytes()
-    for output in outputs:
-        all_outputs += output
-
-    # Create the message to be signed
-    message = all_handles + all_outputs
+    recovered_addresses = []
+    for signature in signatures:
+        recovered_address = recover_address_from_signature(message, signature)
+        # Normalize recovered address to checksum format
+        recovered_address = Web3.to_checksum_address(recovered_address)
+        
+        if recovered_address not in signers_normalized:
+            print(f"Recovered address {recovered_address} not in the list of signers")
+            return False
+        if recovered_address in recovered_addresses:
+            print(f"Same address recovered multiple times")
+            return False
+        recovered_addresses.append(recovered_address)
+        
+    return True
     
-    return verify_signature(public_key, message, signature)
 
-def verify_signature(public_key, message, signature):
-    """Verify the signature of the message."""
+def recover_address_from_signature(message, signature):
+    """Recover the address from the signature."""
 
     if not isinstance(message, (bytes, bytearray)):  
         raise TypeError("message must be of type bytes or bytearray")  
@@ -299,17 +275,13 @@ def verify_signature(public_key, message, signature):
 
     # Hash the message
     message_hash = keccak256(message)
-
-    # Validate public key format: expect 64-byte X||Y  
-    if not isinstance(public_key, (bytes, bytearray)):  
-        raise TypeError("public_key must be of type bytes or bytearray")  
-    if len(public_key) != EC_PUBLIC_KEY_SIZE - 1:  
-        raise ValueError(f"Invalid public key length: {len(public_key)} bytes, must be 64 (X||Y)")  
-
-    # Verify the signature
-    pk = keys.PublicKey(public_key)
-    sig = keys.Signature(signature)
-    return sig.verify_msg_hash(message_hash, pk)
+    
+    # Use eth_keys to recover public key from raw hash (not EIP-191 formatted) and signature
+    sig = keys.Signature(signature_bytes=signature)
+    public_key = sig.recover_public_key_from_msg_hash(message_hash)
+    
+    # Get the address from the public key
+    return public_key.to_address()
 
 def generate_rsa_keypair():
     # Generate RSA key pair

--- a/python/soda_python_sdk/crypto.py
+++ b/python/soda_python_sdk/crypto.py
@@ -241,9 +241,9 @@ def inner_prepare_IT(plaintext, user_aes_key, sender, contract, signing_key, eip
 def verify_signatures(message, signatures, signers):
     """Verify the signatures of the message."""
     # Normalize signers to checksum addresses for comparison
-    signers_normalized = [Web3.to_checksum_address(signer) for signer in signers]
+    signers_normalized = {Web3.to_checksum_address(signer) for signer in signers}
 
-    recovered_addresses = []
+    recovered_addresses = set()
     for signature in signatures:
         recovered_address = recover_address_from_signature(message, signature)
         # Normalize recovered address to checksum format
@@ -255,7 +255,7 @@ def verify_signatures(message, signatures, signers):
         if recovered_address in recovered_addresses:
             print(f"Same address recovered multiple times")
             return False
-        recovered_addresses.append(recovered_address)
+        recovered_addresses.add(recovered_address)
         
     return True
     

--- a/python/soda_python_sdk/test.py
+++ b/python/soda_python_sdk/test.py
@@ -2,7 +2,7 @@ import unittest
 import tempfile
 import os
 from Crypto.Random import get_random_bytes
-from crypto import encrypt, decrypt, load_aes_key, write_aes_key, generate_aes_key, signIT, generate_rsa_keypair, encrypt_rsa, decrypt_rsa, get_func_sig, prepare_IT, generate_ECDSA_private_key, prepare_IT_256, verify_signature
+from crypto import encrypt, decrypt, load_aes_key, write_aes_key, generate_aes_key, signIT, generate_rsa_keypair, encrypt_rsa, decrypt_rsa, get_func_sig, prepare_IT, generate_ECDSA_private_key, prepare_IT_256, verify_signatures
 from crypto import BLOCK_SIZE, ADDRESS_SIZE
 from eth_keys import keys
 from web3 import Account
@@ -144,8 +144,8 @@ class TestMpcHelper(unittest.TestCase):
         # Call the sign function
         signature_bytes = signIT(sender, addr, ct, key)
 
-        public_key = keys.PrivateKey(key).public_key.to_bytes()
-        verified = verify_signature(public_key, sender + addr + ct, signature_bytes)
+        signers = [Account.from_key(key).address]
+        verified = verify_signatures(sender + addr + ct, [signature_bytes], signers)
        
         # Assert
         self.assertEqual(verified, True)


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Refactor signature verification to use address recovery instead of public key comparison

- Support multiple signatures verification with duplicate detection

- Remove PEM file reading and public key validation logic

- Simplify API by accepting signer addresses instead of public keys


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Message + Signatures"] --> B["recoverAddressFromSignature"]
  B --> C["Recovered Addresses"]
  C --> D["verifySignatures"]
  E["Signer List"] --> D
  D --> F["Verification Result"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>crypto.py</strong><dd><code>Refactor to address recovery-based verification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/soda_python_sdk/crypto.py

<ul><li>Replaced <code>verify_signature()</code> with <code>recover_address_from_signature()</code> <br>using ecrecover pattern<br> <li> Replaced <code>verify_encrypt_to_user_signature()</code> with <code>verify_signatures()</code> <br>supporting multiple signatures<br> <li> Removed <code>read_public_key_from_pem()</code> function entirely<br> <li> Added Web3 import for checksum address normalization<br> <li> Changed signature verification to recover addresses and compare <br>against signer list</ul>


</details>


  </td>
  <td><a href="https://github.com/soda-mpc/soda-sdk/pull/49/files#diff-d53c4feba2206a5833b5da6818e6e6fff35def5264eed2c2ec9e35234c2244b5">+29/-57</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>crypto.mjs</strong><dd><code>Refactor to address recovery-based verification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

js/crypto.mjs

<ul><li>Replaced <code>verifySignature()</code> with <code>recoverAddressFromSignature()</code> using <br>ecrecover<br> <li> Replaced <code>verifyEncryptToUserSignature()</code> with <code>verifySignatures()</code> for <br>multiple signatures<br> <li> Removed <code>readPublicKeyFromPem()</code> function and all PEM parsing logic<br> <li> Added checksum address conversion to recovered address<br> <li> Implemented duplicate signature detection across multiple signatures</ul>


</details>


  </td>
  <td><a href="https://github.com/soda-mpc/soda-sdk/pull/49/files#diff-5fcc4a2a330e28c5702faca650ad51058ba254e603035506e57a44043bf59782">+27/-109</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test.py</strong><dd><code>Update tests for new verification API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

python/soda_python_sdk/test.py

<ul><li>Updated import to use <code>verify_signatures</code> instead of <code>verify_signature</code><br> <li> Modified test to pass signer address list instead of public key<br> <li> Changed signature verification call to use new multi-signature API</ul>


</details>


  </td>
  <td><a href="https://github.com/soda-mpc/soda-sdk/pull/49/files#diff-71867494de3182fae9a316c914e2bb12f2eb5a037ad9f1a7b000751782b1b61b">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test.mjs</strong><dd><code>Update tests for new verification API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

js/test.mjs

<ul><li>Updated import to use <code>verifySignatures</code> instead of <code>verifySignature</code><br> <li> Modified test to derive signer address from public key<br> <li> Changed verification call to use new multi-signature API with address <br>list</ul>


</details>


  </td>
  <td><a href="https://github.com/soda-mpc/soda-sdk/pull/49/files#diff-65f4db482cfc04391a5146699b143f8f0dc62637652cf3431a0a125e652321f5">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

